### PR TITLE
Expand Blender production workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,15 @@
 # Blender Agent Studio
 
 [![Validate](https://github.com/ifBars/blender-agent-studio/actions/workflows/validate.yml/badge.svg)](https://github.com/ifBars/blender-agent-studio/actions/workflows/validate.yml)
-[![skills.sh](https://img.shields.io/badge/skills.sh-6%20skills-000000?logo=vercel&logoColor=white)](https://skills.sh/ifBars/blender-agent-studio/blender-agent-studio)
+[![skills.sh](https://img.shields.io/badge/skills.sh-11%20skills-000000?logo=vercel&logoColor=white)](https://skills.sh/ifBars/blender-agent-studio/blender-agent-studio)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-Build, inspect, animate, and benchmark Blender assets with reproducible Python,
-fixed visual evidence, deterministic quality gates, and a bounded local MCP.
+Build, inspect, rig, animate, simulate, render, and benchmark Blender work with reproducible Python,
+explicit graybox-to-polish stages, fixed visual evidence, deterministic quality
+gates, and a bounded local MCP. Finished assets default to a polished smooth
+quality target unless low-poly is explicitly requested.
 
-Blender Agent Studio packages one umbrella routing skill, five specialist
+Blender Agent Studio packages one umbrella routing skill, ten specialist
 skills, and evaluation tools for turning a user request into inspectable
 `.blend` and GLB deliverables. It is designed to answer a harder question than
 “did Blender produce a file?”: does the result satisfy the request, survive
@@ -41,7 +43,7 @@ articulated or animated parts.
 
 ### Full Codex plugin
 
-The marketplace install includes all five skills, the Blender icon and plugin
+The marketplace install includes all ten skills, the Blender icon and plugin
 metadata, and the bounded local MCP:
 
 ```bash
@@ -64,7 +66,7 @@ Install the umbrella routing skill through the Vercel Agent Skills CLI:
 bunx skills add -g ifBars/blender-agent-studio --skill blender-agent-studio --agent codex -y
 ```
 
-Install the umbrella and all five specialist skills:
+Install the umbrella and all ten specialist skills:
 
 ```bash
 bunx skills add -g ifBars/blender-agent-studio --skill "*" --agent codex --full-depth -y
@@ -103,8 +105,13 @@ package contains no machine-specific installation path.
 | Goal | Skill |
 | --- | --- |
 | Build or substantially refine a model | [`blender-modeling-workflow`](https://skills.sh/ifBars/blender-agent-studio/blender-modeling-workflow) |
+| Clarify a brief or create an optional concept reference | `blender-art-direction-intake` |
 | Audit topology, hierarchy, export, or visual quality | [`blender-asset-validation`](https://skills.sh/ifBars/blender-agent-studio/blender-asset-validation) |
 | Create or diagnose articulated mechanical motion | [`blender-animation-workflow`](https://skills.sh/ifBars/blender-agent-studio/blender-animation-workflow) |
+| Create Geometry Nodes, scattering, terrain, or generators | `blender-procedural-workflow` |
+| Light, compose, or deliver still/video renders | `blender-rendering-workflow` |
+| Bake or diagnose fluid and physics simulations | `blender-simulation-workflow` |
+| Rig, skin, animate, or export characters and avatars | `blender-character-workflow` |
 | Measure baseline versus workflow quality | [`blender-agent-benchmark`](https://skills.sh/ifBars/blender-agent-studio/blender-agent-benchmark) |
 | Choose or evaluate a Blender MCP | [`blender-mcp-integration`](https://skills.sh/ifBars/blender-agent-studio/blender-mcp-integration) |
 
@@ -187,10 +194,15 @@ plugins/blender-agent-studio/
   scripts/
   skills/
     blender-agent-benchmark/
+    blender-art-direction-intake/
     blender-animation-workflow/
     blender-asset-validation/
+    blender-character-workflow/
     blender-mcp-integration/
     blender-modeling-workflow/
+    blender-procedural-workflow/
+    blender-rendering-workflow/
+    blender-simulation-workflow/
 ```
 
 The repository root is a Codex marketplace. The installable plugin lives under

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: blender-agent-studio
-description: Route Blender asset creation, refinement, validation, animation, MCP integration, and agent benchmarking work to the appropriate Blender Agent Studio workflow. Use when an agent needs an end-to-end Blender workflow or when the correct modeling, validation, animation, MCP, or benchmark skill is not yet known.
+description: Route Blender asset creation, refinement, procedural systems, rendering, simulations, characters, validation, animation, MCP integration, and agent benchmarking work to the appropriate Blender Agent Studio workflow. Use when an agent needs an end-to-end Blender workflow or when the correct specialist skill is not yet known.
 ---
 
 # Blender Agent Studio
@@ -12,29 +12,48 @@ follow each selected `SKILL.md` completely.
 
 - Build or substantially refine geometry: read
   `plugins/blender-agent-studio/skills/blender-modeling-workflow/SKILL.md`.
+- Clarify art direction or offer a concept/mockup reference before creation:
+  read `plugins/blender-agent-studio/skills/blender-art-direction-intake/SKILL.md`.
 - Inspect an authored scene or exported asset: read
   `plugins/blender-agent-studio/skills/blender-asset-validation/SKILL.md`.
 - Create or diagnose articulated motion: also read
   `plugins/blender-agent-studio/skills/blender-animation-workflow/SKILL.md`.
+- Create Geometry Nodes, scattering, terrain, or parametric systems: read
+  `plugins/blender-agent-studio/skills/blender-procedural-workflow/SKILL.md`.
+- Light, compose, render, or deliver stills, turntables, or sequences: read
+  `plugins/blender-agent-studio/skills/blender-rendering-workflow/SKILL.md`.
+- Build, bake, or diagnose fluids, smoke, fire, cloth, rigid bodies, particles,
+  hair, or soft bodies: read
+  `plugins/blender-agent-studio/skills/blender-simulation-workflow/SKILL.md`.
+- Create, rig, skin, or export a character, avatar, or creature: read
+  `plugins/blender-agent-studio/skills/blender-character-workflow/SKILL.md`.
 - Compare baseline, skill, prompt, or MCP capability: read
   `plugins/blender-agent-studio/skills/blender-agent-benchmark/SKILL.md`.
 - Choose, configure, or evaluate Blender MCP transport: read
   `plugins/blender-agent-studio/skills/blender-mcp-integration/SKILL.md`.
 
-Use modeling plus validation for normal asset-generation requests. Add animation
-only when motion or articulation is required.
+Use modeling plus validation for normal asset-generation requests. Add
+procedural, rendering, simulation, character, or animation workflows only when
+their respective capability is required.
 
 ## Preserve the workflow contract
 
 1. Resolve and record the exact Blender executable and version.
 2. Convert the request into explicit parts, relationships, style, scale,
-   animation, export, and evidence requirements.
-3. Keep deterministic Python as the durable source for generated assets.
-4. Inspect both the authored scene and a fresh import of the exported artifact.
-5. Open and review fixed multiview evidence before claiming visual quality.
-6. Treat automated metrics as gates and measurements, not substitutes for
+   animation, finish quality, export, evidence, and approval requirements.
+3. Unless the user explicitly requests low-poly, blockout-only, or another
+   constrained style, target a polished smooth asset with intentional
+   secondary and tertiary detail rather than a primitive-looking low-density
+   result.
+4. Work through named stages: contract and references, graybox, primary and
+   secondary forms, structural refinement, materials and textures, final
+   surface polish, and export validation.
+5. Keep deterministic Python as the durable source for generated assets.
+6. Inspect both the authored scene and a fresh import of the exported artifact.
+7. Open and review fixed multiview evidence before claiming visual quality.
+8. Treat automated metrics as gates and measurements, not substitutes for
    request compliance or visual judgment.
-7. Keep benchmark conditions isolated and report failures, timing, and
+9. Keep benchmark conditions isolated and report failures, timing, and
    limitations alongside improvements.
 
 Prefer the bundled bounded inspection and evidence tools when installed as a

--- a/plugins/blender-agent-studio/.codex-plugin/plugin.json
+++ b/plugins/blender-agent-studio/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "blender-agent-studio",
-  "version": "0.1.0",
-  "description": "Evidence-driven Blender 5.2 modeling, validation, animation, and agent benchmarking workflows.",
+  "version": "0.2.0+codex.20260731082550",
+  "description": "Evidence-driven Blender 5.2 modeling, procedural, rendering, simulation, character, validation, animation, and benchmark workflows.",
   "author": {
     "name": "Bars",
     "url": "https://github.com/ifBars"
@@ -19,8 +19,8 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Blender Agent Studio",
-    "shortDescription": "Build and benchmark better Blender assets",
-    "longDescription": "Procedural Blender 5.2 workflows for creating reproducible models, validating technical and visual quality, refining mechanical animation, and measuring agent improvements with paired benchmarks.",
+    "shortDescription": "Build, simulate, render, and benchmark Blender work",
+    "longDescription": "Evidence-driven Blender 5.2 workflows for reproducible models, Geometry Nodes, rendering, physics simulations, character rigs, validation, animation, and paired agent benchmarks.",
     "developerName": "Bars",
     "category": "Developer Tools",
     "websiteURL": "https://github.com/ifBars/blender-agent-studio",
@@ -30,7 +30,9 @@
     ],
     "defaultPrompt": [
       "Build a Blender model from this request.",
+      "Clarify this Blender brief and create an optional concept mockup.",
       "Validate this Blender asset and render evidence.",
+      "Create and validate a Blender fluid or physics simulation.",
       "Benchmark this Blender agent workflow."
     ],
     "brandColor": "#E87D0D",

--- a/plugins/blender-agent-studio/README.md
+++ b/plugins/blender-agent-studio/README.md
@@ -1,19 +1,29 @@
 # Blender Agent Studio
 
 Blender Agent Studio is a global Codex plugin for reproducible Blender 5.2
-modeling, technical and visual validation, mechanical animation, MCP selection,
-and paired agent benchmarking.
+modeling, procedural systems, rendering, simulation, character work, technical
+and visual validation, animation, MCP selection, and paired agent benchmarking.
 
 ## What it provides
 
 - `blender-modeling-workflow`: contract-first procedural modeling and
+  explicit graybox-to-polish stages with a smooth finished-quality default and
   iterative multiview review.
 - `blender-asset-validation`: evaluated geometry inspection, fresh GLB import,
   and fixed evidence renders.
 - `blender-animation-workflow`: critical-frame review, mechanical pivots, and
   dynamic-connector endpoint invariants.
+- `blender-procedural-workflow`: editable Geometry Nodes, modifiers,
+  instancing, terrain, and generator validation.
+- `blender-rendering-workflow`: reproducible lighting, camera, compositing,
+  still, turntable, and sequence delivery.
+- `blender-simulation-workflow`: controlled fluid, smoke, fire, rigid, cloth,
+  particle, hair, and soft-body bakes with cache evidence.
+- `blender-character-workflow`: character topology, armatures, skinning,
+  deformation poses, actions, and fresh-import checks.
 - `blender-agent-benchmark`: isolated baseline/plugin runs, task gates,
-  clean-source reproduction, rescoring, and blinded pairwise judging.
+  clean-source reproduction, finish-profile controls, rescoring, and
+  counterbalanced blinded pairwise judging.
 - `blender-mcp-integration`: guidance for Blender Lab MCP, the bundled bounded
   evaluator MCP, and optional community integrations.
 - A local MCP with exact Blender version, asset inspection, and evidence render
@@ -39,8 +49,8 @@ bun run benchmark --suite quick --mode skills --output C:\bench\skills
 ```
 
 Every output directory must be new so raw traces and artifacts remain
-immutable. The automated score is structural; use the bundled blinded
-comparison before making a visual-quality claim.
+immutable. The automated score includes structural and finish-signal proxies;
+use the bundled blinded comparison before making a visual-quality claim.
 
 ## MCP decision
 

--- a/plugins/blender-agent-studio/skills/blender-agent-benchmark/SKILL.md
+++ b/plugins/blender-agent-studio/skills/blender-agent-benchmark/SKILL.md
@@ -18,6 +18,9 @@ Measure changes with the same tasks, model, effort, limits, Blender build, and e
 7. Evaluate outputs after generation. Do not leak hidden rubric details to the agent.
 
 Read [references/methodology.md](references/methodology.md) before changing fixtures, scoring, or comparison claims.
+Read [references/open-source-benchmark-landscape.md](references/open-source-benchmark-landscape.md)
+when designing new suites or borrowing evaluation ideas from other Blender
+benchmarks.
 Read [references/validated-results.md](references/validated-results.md) only
 when reviewing the plugin's recorded validation result, not while generating a
 benchmark submission.
@@ -61,6 +64,9 @@ Keep these dimensions separate:
 - execution/export validity;
 - prompt and structural compliance;
 - geometry/game-readiness;
+- finish-profile compliance, including polished-smooth versus explicitly
+  low-poly intent;
+- UV, shading, refinement, material, texture, and presentation signals;
 - multiview visual quality;
 - physical plausibility;
 - animation quality when applicable;
@@ -68,6 +74,8 @@ Keep these dimensions separate:
 - time, turns, tool failures, and cost.
 
 Use hard gates before the weighted score. Prefer blinded pairwise visual review over uncalibrated absolute aesthetic scores.
+Counterbalance A/B image order across judges and preserve per-judge mappings.
+Do not let a low triangle count compensate for a blockout-looking final asset.
 
 ## Iterate
 

--- a/plugins/blender-agent-studio/skills/blender-agent-benchmark/references/methodology.md
+++ b/plugins/blender-agent-studio/skills/blender-agent-benchmark/references/methodology.md
@@ -12,7 +12,13 @@ Run `baseline` versus `skills` first. Compare `skills` versus `skills_mcp` separ
 
 - `smoke`: one simple task; validates the harness only.
 - `quick`: at least one prop, one multi-part assembly, and one animation task.
-- `full`: broader categories with at least three repetitions and holdouts.
+- `full`: broader categories with at least three repetitions, holdouts, a
+  polished-smooth finish task, and an explicitly low-poly control.
+
+Tag every fixture by task category, capability coverage, and finish profile.
+Track at least geometry, materials, placement/spatial relations, animation when
+applicable, and instruction following. Lighting and texture coverage should be
+reported when a task genuinely exposes those dimensions.
 
 ## Required controls
 
@@ -22,23 +28,44 @@ Run `baseline` versus `skills` first. Compare `skills` versus `skills_mcp` separ
 - same exact Blender executable;
 - clean task directories;
 - deterministic evaluator version;
-- randomized or hidden condition labels for visual judging.
+- hidden condition labels and counterbalanced A/B image order for visual
+  judging.
+- raw Codex JSON events plus summarized duration, tool calls, tool failures,
+  error items, and token usage.
 
 ## Scoring
 
 Reject invalid submissions before computing a quality score. Preserve a dimension vector even when presenting a weighted headline.
 
-Suggested default weights for static assets:
+Suggested reader-facing dimensions for static assets:
 
 - specification compliance: 25;
-- multiview visual quality: 20;
+- multiview visual quality and final-stage completeness: 20;
 - geometry and game-readiness: 15;
 - physical/assembly plausibility: 15;
-- materials and presentation: 10;
+- materials, textures, surface finish, and presentation: 15;
 - context/export correctness: 10;
 - reproducibility: 5.
 
 Animation fixtures replace irrelevant static weight with animation quality.
+
+The deterministic scorer is a proxy layer. It should detect finish signals such
+as UV coverage, smooth-versus-flat shading appropriate to the requested finish
+profile, and refinement evidence, but those signals must not replace blinded
+multiview review. A model can game polygon counts, modifier counts, or material
+counts without producing a good asset.
+
+Preserve two distinct controls:
+
+- polished-smooth is the default unless the task explicitly requests another
+  finish;
+- explicitly low-poly fixtures should penalize unwanted smoothing or
+  subdivision rather than rewarding the default.
+
+For visual comparison, give judges the actual visible requirements, score
+surface finish, material/texture quality, lighting/presentation, and
+final-stage completeness separately, and alternate the A/B order between
+judges to reduce position bias.
 
 ## Claims
 
@@ -47,3 +74,7 @@ Animation fixtures replace irrelevant static weight with animation quality.
 - A plugin gain is credible when it repeats across task types, does not regress hard gates, and survives a holdout.
 - Report failures and excluded rows.
 - Keep raw metrics and artifacts so scoring changes can be recomputed without rerunning agents.
+- Treat total tokens as a usage proxy, not a dollar-cost claim, unless actual
+  billing data is available.
+- Do not compare rescored historical runs with new runs unless the inspector and
+  scorer schema versions are compatible or the limitation is stated.

--- a/plugins/blender-agent-studio/skills/blender-agent-benchmark/references/open-source-benchmark-landscape.md
+++ b/plugins/blender-agent-studio/skills/blender-agent-benchmark/references/open-source-benchmark-landscape.md
@@ -1,0 +1,88 @@
+# Open-source Blender benchmark landscape
+
+Research refreshed 2026-07-27. These projects inform the local methodology;
+they are not bundled, copied, or claimed as equivalent benchmark conditions.
+
+## BlenderGym
+
+Primary sources:
+
+- https://blendergym.github.io/
+- https://github.com/richard-guyunqi/BlenderGym-Open
+- https://arxiv.org/abs/2504.01786
+
+BlenderGym provides 245 hand-crafted start/goal Blender scene pairs across
+procedural geometry, lighting, procedural materials, blend shapes, and object
+placement. Instances include Blender files, start and goal scripts, renders,
+and language descriptions. Its evaluator uses task-appropriate image and 3D
+metrics and its generator/verifier experiments separate generation work from
+verification work.
+
+Applicable lessons:
+
+- report capability coverage rather than treating “Blender” as one task;
+- preserve fixed inputs, outputs, and evaluator versions;
+- add reference-scene editing as a separate future lane instead of mixing it
+  into from-scratch asset creation;
+- measure verification effort as well as generation effort;
+- prefer deterministic reference metrics when a true goal scene exists.
+
+## CADBench / BlenderLLM
+
+Primary sources:
+
+- https://github.com/FreedomIntelligence/BlenderLLM
+- https://huggingface.co/datasets/FreedomIntelligence/CADBench
+- https://arxiv.org/abs/2412.14203
+
+CADBench contains 700 text-to-Blender-script examples: 500 simulated prompts
+and 200 prompts collected from online forums. Its criteria are grouped around
+object attributes, spatial relationships, and instruction satisfaction, and it
+reports syntax failures separately.
+
+Applicable lessons:
+
+- keep synthetic fixtures and user-like or “wild” holdouts distinct;
+- express requirements as multiple task-specific criteria instead of relying
+  on one object name or one aesthetic score;
+- keep script execution/syntax validity separate from semantic and spatial
+  correctness;
+- retain short prompts as well as detailed prompts so benchmark performance
+  does not depend on unusually complete user specifications.
+
+## EZBlender
+
+Primary source:
+
+- https://arxiv.org/abs/2601.07143
+
+EZBlender uses a Plan-and-ReAct design and evaluates multi-task editing while
+also analyzing responsiveness and economic efficiency.
+
+Applicable lessons:
+
+- record planning/decomposition and verification stages without leaking hidden
+  rubric answers into the generation prompt;
+- report duration, failures, and cost or token proxies beside quality;
+- compare an improvement under identical tool permissions and time limits;
+- evaluate iterative editing separately from one-shot creation.
+
+## Local adoption
+
+Blender Agent Studio currently adopts:
+
+- capability and finish-profile tags on fixtures;
+- polished-smooth default tasks plus an explicit low-poly control;
+- deterministic execution/export, geometry, UV, shading, and refinement
+  signals;
+- task-specific visible briefs for judges;
+- counterbalanced blinded A/B order across judges;
+- separate automated, multiview, animation, timing, and failure evidence.
+
+Still separate future lanes:
+
+- fixed start/goal scene editing with photometric, CLIP, or Chamfer-style
+  reference metrics;
+- material-only, lighting-only, placement-only, and blend-shape suites;
+- calibrated human baselines;
+- larger “wild prompt” sampling with licensing and provenance review.

--- a/plugins/blender-agent-studio/skills/blender-agent-benchmark/references/validated-results.md
+++ b/plugins/blender-agent-studio/skills/blender-agent-benchmark/references/validated-results.md
@@ -2,6 +2,11 @@
 
 Date: 2026-07-24 Pacific / 2026-07-25 UTC.
 
+Historical note: this result predates inspector schema 2 and scorer version 3,
+which add UV, shading, refinement, finish-profile, and counterbalanced judge
+dimensions. Preserve it as evidence for the earlier methodology; do not compare
+its 100-point automated scores directly with newly generated runs.
+
 Environment:
 
 - Blender 5.2.0 LTS, build `fbe6228777e7`;

--- a/plugins/blender-agent-studio/skills/blender-agent-benchmark/scripts/compare_runs.ts
+++ b/plugins/blender-agent-studio/skills/blender-agent-benchmark/scripts/compare_runs.ts
@@ -1,6 +1,7 @@
 import { copyFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
+import { BENCHMARK_TASKS } from "./tasks.ts";
 
 type RunResult = {
   taskId: string;
@@ -17,6 +18,13 @@ type RunSummary = {
   mode: string;
   model: string;
   reasoning: string;
+  execution?: {
+    totalDurationMs: number;
+    totalToolCalls: number;
+    totalToolFailures: number;
+    totalErrors: number;
+    totalTokens: number;
+  };
   results: RunResult[];
 };
 
@@ -134,6 +142,10 @@ const schema = {
         "constructionPlausibility",
         "craftsmanshipAndDetail",
         "materialsAndReadability",
+        "surfaceFinishAndShading",
+        "materialTextureQuality",
+        "lightingAndPresentation",
+        "finalStageCompleteness",
         "multiviewConsistency",
       ],
       properties: {
@@ -142,11 +154,28 @@ const schema = {
         constructionPlausibility: { type: "number", minimum: 0, maximum: 10 },
         craftsmanshipAndDetail: { type: "number", minimum: 0, maximum: 10 },
         materialsAndReadability: { type: "number", minimum: 0, maximum: 10 },
+        surfaceFinishAndShading: { type: "number", minimum: 0, maximum: 10 },
+        materialTextureQuality: { type: "number", minimum: 0, maximum: 10 },
+        lightingAndPresentation: { type: "number", minimum: 0, maximum: 10 },
+        finalStageCompleteness: { type: "number", minimum: 0, maximum: 10 },
         multiviewConsistency: { type: "number", minimum: 0, maximum: 10 },
       },
     },
   },
 };
+
+const VISUAL_DIMENSIONS = [
+  "taskFidelity",
+  "silhouetteAndProportion",
+  "constructionPlausibility",
+  "craftsmanshipAndDetail",
+  "materialsAndReadability",
+  "surfaceFinishAndShading",
+  "materialTextureQuality",
+  "lightingAndPresentation",
+  "finalStageCompleteness",
+  "multiviewConsistency",
+] as const;
 
 async function main(): Promise<void> {
   const baselinePath = argument("--baseline");
@@ -188,19 +217,12 @@ async function main(): Promise<void> {
       `${baselineResult.taskId}-r${String(baselineResult.repetition).padStart(2, "0")}`,
     );
     await mkdir(pairDir, { recursive: true });
-    const reverse = crypto.getRandomValues(new Uint8Array(1))[0] % 2 === 1;
-    const sourceA = reverse
-      ? candidateResult.evidenceContactSheet
-      : baselineResult.evidenceContactSheet;
-    const sourceB = reverse
-      ? baselineResult.evidenceContactSheet
-      : candidateResult.evidenceContactSheet;
-    const imageA = join(pairDir, "candidate-a.png");
-    const imageB = join(pairDir, "candidate-b.png");
-    await copyFile(sourceA, imageA);
-    await copyFile(sourceB, imageB);
-    const attachedImages = [imageA, imageB];
-    let animationPrompt = "";
+    const task = BENCHMARK_TASKS.find(
+      (item) => item.id === baselineResult.taskId,
+    );
+    if (!task) {
+      throw new Error(`Unknown benchmark task: ${baselineResult.taskId}`);
+    }
     const baselineAnimation =
       baselineResult.animationContactSheet ??
       join(
@@ -213,39 +235,62 @@ async function main(): Promise<void> {
         dirname(candidateResult.evidenceContactSheet),
         "animation_contact_sheet.png",
       );
-    if (existsSync(baselineAnimation) && existsSync(candidateAnimation)) {
-      const animationSourceA = reverse
-        ? candidateAnimation
-        : baselineAnimation;
-      const animationSourceB = reverse
-        ? baselineAnimation
-        : candidateAnimation;
-      const animationA = join(pairDir, "candidate-a-animation.png");
-      const animationB = join(pairDir, "candidate-b-animation.png");
-      await copyFile(animationSourceA, animationA);
-      await copyFile(animationSourceB, animationB);
-      attachedImages.push(animationA, animationB);
-      animationPrompt =
-        " The third image shows candidate A at the requested critical animation frames; the fourth shows candidate B at those frames. Evaluate mechanical motion, pivots, continuity, and whether the sequence communicates the requested operation.";
-    }
-    const mapping = reverse
-      ? { A: candidate.mode, B: baseline.mode }
-      : { A: baseline.mode, B: candidate.mode };
-    await writeFile(
-      join(pairDir, "mapping.hidden.json"),
-      JSON.stringify(mapping, null, 2),
-      "utf8",
-    );
-
-    const judgeResults: JudgeResult[] = [];
+    const hasAnimation =
+      existsSync(baselineAnimation) && existsSync(candidateAnimation);
+    const firstReverse =
+      crypto.getRandomValues(new Uint8Array(1))[0] % 2 === 1;
+    const judgeResults: Array<{
+      mapping: { A: string; B: string };
+      decodedWinner: string;
+      scoresByMode: Record<string, Record<string, number>>;
+      result: JudgeResult;
+    }> = [];
     for (let index = 0; index < judges; index += 1) {
       const judgeDir = join(pairDir, `judge-${String(index + 1).padStart(2, "0")}`);
       await mkdir(judgeDir, { recursive: true });
+      const reverse = index % 2 === 0 ? firstReverse : !firstReverse;
+      const sourceA = reverse
+        ? candidateResult.evidenceContactSheet
+        : baselineResult.evidenceContactSheet;
+      const sourceB = reverse
+        ? baselineResult.evidenceContactSheet
+        : candidateResult.evidenceContactSheet;
+      const imageA = join(judgeDir, "candidate-a.png");
+      const imageB = join(judgeDir, "candidate-b.png");
+      await copyFile(sourceA, imageA);
+      await copyFile(sourceB, imageB);
+      const attachedImages = [imageA, imageB];
+      let animationPrompt = "";
+      if (hasAnimation) {
+        const animationSourceA = reverse
+          ? candidateAnimation
+          : baselineAnimation;
+        const animationSourceB = reverse
+          ? baselineAnimation
+          : candidateAnimation;
+        const animationA = join(judgeDir, "candidate-a-animation.png");
+        const animationB = join(judgeDir, "candidate-b-animation.png");
+        await copyFile(animationSourceA, animationA);
+        await copyFile(animationSourceB, animationB);
+        attachedImages.push(animationA, animationB);
+        animationPrompt =
+          " The third image shows candidate A at the requested critical animation frames; the fourth shows candidate B at those frames. Evaluate mechanical motion, pivots, continuity, and whether the sequence communicates the requested operation.";
+      }
+      const mapping = reverse
+        ? { A: candidate.mode, B: baseline.mode }
+        : { A: baseline.mode, B: candidate.mode };
+      await writeFile(
+        join(judgeDir, "mapping.hidden.json"),
+        JSON.stringify(mapping, null, 2),
+        "utf8",
+      );
       const prompt = `You are a strict blinded 3D asset art director. The first attached contact sheet is candidate A and the second is candidate B. Both show fixed perspective, front, back, left, right, and top views of assets made from the same request.${animationPrompt}
 
-Compare only visible evidence. Do not infer quality from filenames or likely generation method. Penalize floating or mechanically unexplained parts, accidental intersections, weak silhouettes, incoherent proportions, missing requested relationships, generic primitive assembly, poor material separation, inconsistent detail, broken views, and presentation tricks that hide defects. Reward clear task fidelity, plausible construction, readable forms, intentional detail, coherent style, and consistency across every view. A tie is valid.
+Compare only visible evidence. Do not infer quality from filenames or likely generation method. Penalize floating or mechanically unexplained parts, accidental intersections, weak silhouettes, incoherent proportions, missing requested relationships, generic primitive assembly, visible faceting when smooth finish was requested, unwanted smoothing when low-poly was requested, blockout residue, razor edges, poor texture or material separation, inconsistent detail, broken lighting, broken views, and presentation tricks that hide defects. Reward clear task fidelity, plausible construction, readable primary through tertiary forms, intentional surface refinement, coherent materials and textures, balanced presentation, and consistency across every view. A technically valid model that still looks like a graybox should score poorly on finalStageCompleteness. A tie is valid.
 
 Task: ${baselineResult.taskTitle}
+Finish profile: ${task.rubric.finishProfile}
+Visible requirements: ${task.visualBrief}
 
 Return the required JSON only. Keep rationale concise and specific.`;
       const judged = await judgePair({
@@ -269,11 +314,20 @@ Return the required JSON only. Keep rationale concise and specific.`;
         ),
         "utf8",
       );
-      judgeResults.push(judged.result);
+      judgeResults.push({
+        mapping,
+        decodedWinner:
+          judged.result.winner === "tie"
+            ? "tie"
+            : mapping[judged.result.winner],
+        scoresByMode: {
+          [mapping.A]: judged.result.scores.A,
+          [mapping.B]: judged.result.scores.B,
+        },
+        result: judged.result,
+      });
     }
-    const decodedWinners = judgeResults.map((item) =>
-      item.winner === "tie" ? "tie" : mapping[item.winner],
-    );
+    const decodedWinners = judgeResults.map((item) => item.decodedWinner);
     comparisons.push({
       taskId: baselineResult.taskId,
       repetition: baselineResult.repetition,
@@ -293,10 +347,33 @@ Return the required JSON only. Keep rationale concise and specific.`;
     hardGates: { baseline: boolean; candidate: boolean };
     baselineAutomatedScore: number;
     candidateAutomatedScore: number;
+    judgeResults: Array<{
+      scoresByMode: Record<string, Record<string, number>>;
+    }>;
   }>;
   const allVotes = typed.flatMap((item) => item.visualWinnerVotes);
+  const allJudgeResults = typed.flatMap((item) => item.judgeResults);
+  const meanDimensions = (mode: string) =>
+    Object.fromEntries(
+      VISUAL_DIMENSIONS.map((dimension) => {
+        const values = allJudgeResults
+          .map((item) => item.scoresByMode[mode]?.[dimension])
+          .filter((value): value is number => Number.isFinite(value));
+        return [
+          dimension,
+          values.length
+            ? Number(
+                (
+                  values.reduce((sum, value) => sum + value, 0) /
+                  values.length
+                ).toFixed(3),
+              )
+            : null,
+        ];
+      }),
+    );
   const summary = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     createdAt: new Date().toISOString(),
     baselineMode: baseline.mode,
     candidateMode: candidate.mode,
@@ -305,6 +382,8 @@ Return the required JSON only. Keep rationale concise and specific.`;
     judgeModel: model,
     judgeReasoning: reasoning,
     judgeCountPerPair: judges,
+    positionOrderPolicy:
+      "Randomize the first judge's A/B mapping, then alternate the mapping for each later judge.",
     candidateHardGateRegressions: typed.filter(
       (item) => item.hardGates.baseline && !item.hardGates.candidate,
     ).length,
@@ -321,14 +400,42 @@ Return the required JSON only. Keep rationale concise and specific.`;
           ).toFixed(2),
         )
       : null,
+    execution: {
+      baseline: baseline.execution ?? null,
+      candidate: candidate.execution ?? null,
+      candidateMinusBaseline:
+        baseline.execution && candidate.execution
+          ? {
+              durationMs:
+                candidate.execution.totalDurationMs -
+                baseline.execution.totalDurationMs,
+              toolCalls:
+                candidate.execution.totalToolCalls -
+                baseline.execution.totalToolCalls,
+              toolFailures:
+                candidate.execution.totalToolFailures -
+                baseline.execution.totalToolFailures,
+              errorItems:
+                candidate.execution.totalErrors -
+                baseline.execution.totalErrors,
+              totalTokens:
+                candidate.execution.totalTokens -
+                baseline.execution.totalTokens,
+            }
+          : null,
+    },
     visualVotes: {
       baseline: allVotes.filter((vote) => vote === baseline.mode).length,
       candidate: allVotes.filter((vote) => vote === candidate.mode).length,
       tie: allVotes.filter((vote) => vote === "tie").length,
     },
+    visualDimensionMeans: {
+      baseline: meanDimensions(baseline.mode),
+      candidate: meanDimensions(candidate.mode),
+    },
     comparisons,
     caveat:
-      "Model-based visual judging is blinded and repeatable but is still a proxy. Preserve contact sheets for human review.",
+      "Model-based visual judging is blinded and A/B-counterbalanced but is still a proxy. Preserve contact sheets and per-judge records for human review.",
   };
   await writeFile(
     join(output, "comparison-summary.json"),

--- a/plugins/blender-agent-studio/skills/blender-agent-benchmark/scripts/rescore_run.ts
+++ b/plugins/blender-agent-studio/skills/blender-agent-benchmark/scripts/rescore_run.ts
@@ -67,7 +67,7 @@ async function main(): Promise<void> {
   const rescored = {
     ...summary,
     rescoredAt: new Date().toISOString(),
-    scorerVersion: 2,
+    scorerVersion: 3,
     hardGatePasses: results.filter((item) => item.score.hardGatePass).length,
     meanAutomatedScore: Number(
       (

--- a/plugins/blender-agent-studio/skills/blender-agent-benchmark/scripts/run_benchmark.ts
+++ b/plugins/blender-agent-studio/skills/blender-agent-benchmark/scripts/run_benchmark.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../scripts/blender-process.ts";
 import { scoreSubmission } from "./score.ts";
 import { BENCHMARK_TASKS } from "./tasks.ts";
+import { summarizeAgentEvents } from "./trace.ts";
 
 type Mode = "baseline" | "skills" | "skills_mcp";
 type Suite = "smoke" | "quick" | "full";
@@ -308,7 +309,7 @@ async function main(): Promise<void> {
     versionProc.exited,
   ]);
   const runManifest = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     startedAt: new Date().toISOString(),
     mode: options.mode,
     suite: options.suite,
@@ -319,6 +320,13 @@ async function main(): Promise<void> {
     codexVersion: codexVersion.trim(),
     codexVersionError: codexVersionError.trim(),
     taskIds: selected.map((task) => task.id),
+    taskCategories: [...new Set(selected.map((task) => task.category))].sort(),
+    capabilityCoverage: [
+      ...new Set(selected.flatMap((task) => task.capabilities)),
+    ].sort(),
+    finishProfiles: [
+      ...new Set(selected.map((task) => task.rubric.finishProfile)),
+    ].sort(),
     bypassApprovals: options.bypassApprovals,
   };
   await writeFile(
@@ -370,6 +378,7 @@ async function main(): Promise<void> {
         "utf8",
       );
       await writeFile(join(workdir, "agent-events.jsonl"), agent.stdout, "utf8");
+      const agentTrace = summarizeAgentEvents(agent.stdout);
 
       const sourcePath = join(workdir, "create_asset.py");
       const blendPath = join(workdir, "asset.blend");
@@ -418,6 +427,7 @@ async function main(): Promise<void> {
           exitCode: agent.exitCode,
           timedOut: agent.timedOut,
           durationMs: agent.durationMs,
+          trace: agentTrace,
         },
         score,
         evidenceContactSheet: existsSync(
@@ -445,6 +455,10 @@ async function main(): Promise<void> {
 
   const numericResults = results as Array<{
     score: { score: number; hardGatePass: boolean };
+    agent: {
+      durationMs: number;
+      trace: ReturnType<typeof summarizeAgentEvents>;
+    };
   }>;
   const summary = {
     ...runManifest,
@@ -458,8 +472,40 @@ async function main(): Promise<void> {
         numericResults.length
       ).toFixed(2),
     ),
+    execution: {
+      totalDurationMs: numericResults.reduce(
+        (sum, item) => sum + item.agent.durationMs,
+        0,
+      ),
+      totalToolCalls: numericResults.reduce(
+        (sum, item) => sum + item.agent.trace.toolCalls,
+        0,
+      ),
+      totalToolFailures: numericResults.reduce(
+        (sum, item) => sum + item.agent.trace.toolFailures,
+        0,
+      ),
+      totalErrors: numericResults.reduce(
+        (sum, item) => sum + item.agent.trace.errors,
+        0,
+      ),
+      totalInputTokens: numericResults.reduce(
+        (sum, item) => sum + item.agent.trace.usage.inputTokens,
+        0,
+      ),
+      totalOutputTokens: numericResults.reduce(
+        (sum, item) => sum + item.agent.trace.usage.outputTokens,
+        0,
+      ),
+      totalTokens: numericResults.reduce(
+        (sum, item) => sum + item.agent.trace.usage.totalTokens,
+        0,
+      ),
+      tokenCaveat:
+        "Total tokens are a usage proxy, not a dollar-cost measurement. Cached and cache-write input tokens are reported per result.",
+    },
     warning:
-      "This is a deterministic structural score, not a complete quality score. Use blinded multiview review before making a quality claim.",
+      "The automated score includes structural and finish-signal proxies, not a complete aesthetic judgment. Use counterbalanced blinded multiview review before making a quality claim.",
     results,
   };
   await writeFile(

--- a/plugins/blender-agent-studio/skills/blender-agent-benchmark/scripts/score.test.ts
+++ b/plugins/blender-agent-studio/skills/blender-agent-benchmark/scripts/score.test.ts
@@ -37,6 +37,10 @@ function completeMetrics() {
       invalid_vertices: 0,
       degenerate_faces: 0,
       zero_length_edges: 0,
+      smooth_polygons: 3_000,
+      flat_polygons: 1_200,
+      uv_mapped_meshes: 8,
+      refinement_modifiers: 2,
     },
   };
 }
@@ -77,7 +81,72 @@ describe("scoreSubmission", () => {
     });
 
     expect(score.hardGatePass).toBe(false);
-    expect(score.dimensions.specificationCoverage).toBe(10);
+    expect(score.dimensions.specificationCoverage).toBeCloseTo(8.33, 2);
     expect(score.score).toBeLessThan(100);
+  });
+
+  test("does not award a perfect score to an unrefined blockout", () => {
+    const metrics = completeMetrics();
+    metrics.totals.smooth_polygons = 0;
+    metrics.totals.flat_polygons = 4_200;
+    metrics.totals.uv_mapped_meshes = 0;
+    metrics.totals.refinement_modifiers = 0;
+    metrics.totals.triangles = 1_300;
+
+    const score = scoreSubmission({
+      task: lantern,
+      agentExitCode: 0,
+      sourceExists: true,
+      reproductionPass: true,
+      blendExists: true,
+      glbExists: true,
+      blendMetrics: metrics,
+      glbMetrics: completeMetrics(),
+    });
+
+    expect(score.hardGatePass).toBe(true);
+    expect(score.dimensions.finishQuality).toBe(0);
+    expect(score.score).toBe(89);
+  });
+
+  test("preserves intentional low-poly finish requirements", () => {
+    const lowPolyTask = BENCHMARK_TASKS.find(
+      (task) => task.id === "low_poly_radio_control",
+    )!;
+    const metrics = completeMetrics();
+    metrics.objects = [
+      { name: "Body", parent: null },
+      { name: "Speaker_Grille", parent: "Body" },
+      { name: "Tuning_Display", parent: "Body" },
+      { name: "Knob_A", parent: "Body" },
+      { name: "Knob_B", parent: "Body" },
+      { name: "Handle", parent: "Body" },
+      { name: "Antenna", parent: "Body" },
+      { name: "Corner_Guard", parent: "Body" },
+      { name: "Battery_Compartment", parent: "Body" },
+    ];
+    metrics.totals.mesh_objects = 9;
+    metrics.totals.materials = 3;
+    metrics.totals.triangles = 1_200;
+    metrics.totals.smooth_polygons = 100;
+    metrics.totals.flat_polygons = 1_100;
+    metrics.totals.uv_mapped_meshes = 9;
+    metrics.totals.refinement_modifiers = 0;
+    metrics.scene.bounds.dimensions = [0.8, 0.4, 0.5];
+
+    const score = scoreSubmission({
+      task: lowPolyTask,
+      agentExitCode: 0,
+      sourceExists: true,
+      reproductionPass: true,
+      blendExists: true,
+      glbExists: true,
+      blendMetrics: metrics,
+      glbMetrics: metrics,
+    });
+
+    expect(score.hardGatePass).toBe(true);
+    expect(score.dimensions.finishQuality).toBe(11);
+    expect(score.score).toBe(100);
   });
 });

--- a/plugins/blender-agent-studio/skills/blender-agent-benchmark/scripts/score.ts
+++ b/plugins/blender-agent-studio/skills/blender-agent-benchmark/scripts/score.ts
@@ -3,7 +3,13 @@ import type { BenchmarkTask } from "./tasks.ts";
 type AssetMetrics = {
   hard_gate_pass?: boolean;
   materials?: string[];
-  meshes?: Array<{ name?: string }>;
+  meshes?: Array<{
+    name?: string;
+    uv_layers?: number;
+    smooth_polygons?: number;
+    flat_polygons?: number;
+    refinement_modifiers?: Array<{ type?: string }>;
+  }>;
   objects?: Array<{ name?: string; parent?: string | null; action?: string | null }>;
   actions?: Array<{ frame_start?: number; frame_end?: number; name?: string }>;
   scene?: { bounds?: { dimensions?: number[] }; frame_start?: number; frame_end?: number };
@@ -14,6 +20,10 @@ type AssetMetrics = {
     invalid_vertices?: number;
     degenerate_faces?: number;
     zero_length_edges?: number;
+    smooth_polygons?: number;
+    flat_polygons?: number;
+    uv_mapped_meshes?: number;
+    refinement_modifiers?: number;
   };
 };
 
@@ -25,6 +35,7 @@ export type AutomatedScore = {
     specificationCoverage: number;
     geometryReadiness: number;
     materialsAndPresentation: number;
+    finishQuality: number;
     animationOrAssembly: number;
     reproducibility: number;
   };
@@ -108,9 +119,9 @@ export function scoreSubmission(options: {
   add(
     "semantic_part_coverage",
     coverage === 1,
-    30,
+    25,
     `${matchedGroups.length}/${task.rubric.requiredNameGroups.length} required semantic part groups found`,
-    coverage * 30,
+    coverage * 25,
   );
 
   const triangles = blendMetrics?.totals?.triangles ?? 0;
@@ -118,7 +129,7 @@ export function scoreSubmission(options: {
   add(
     "triangle_range",
     triangles >= minimumTriangles && triangles <= maximumTriangles,
-    6,
+    5,
     `${triangles} triangles; expected ${minimumTriangles}-${maximumTriangles}`,
   );
   const meshObjects = blendMetrics?.totals?.mesh_objects ?? 0;
@@ -126,9 +137,9 @@ export function scoreSubmission(options: {
   add(
     "mesh_object_count",
     objectRatio === 1,
-    5,
+    4,
     `${meshObjects} mesh objects; minimum ${task.rubric.minimumMeshObjects}`,
-    objectRatio * 5,
+    objectRatio * 4,
   );
   const invalidCount =
     (blendMetrics?.totals?.invalid_vertices ?? 0) +
@@ -137,14 +148,14 @@ export function scoreSubmission(options: {
   add(
     "invalid_geometry",
     invalidCount === 0,
-    5,
+    4,
     `${invalidCount} invalid vertices, degenerate faces, or zero-length edges`,
   );
   const extent = Math.max(...(blendMetrics?.scene?.bounds?.dimensions ?? [Infinity]));
   add(
     "maximum_extent",
     extent <= task.rubric.maximumExtent,
-    4,
+    2,
     `${Number.isFinite(extent) ? extent.toFixed(3) : "missing"}m maximum extent; limit ${task.rubric.maximumExtent}m`,
   );
 
@@ -153,9 +164,9 @@ export function scoreSubmission(options: {
   add(
     "material_count",
     materialRatio === 1,
-    7,
+    5,
     `${materials} materials; minimum ${task.rubric.minimumMaterials}`,
-    materialRatio * 7,
+    materialRatio * 5,
   );
   const glbMaterials = glbMetrics?.totals?.materials ?? 0;
   add(
@@ -163,6 +174,65 @@ export function scoreSubmission(options: {
     glbMaterials >= Math.min(materials, task.rubric.minimumMaterials),
     3,
     `${glbMaterials} materials survived GLB import`,
+  );
+
+  const uvMappedMeshes = blendMetrics?.totals?.uv_mapped_meshes ?? 0;
+  const uvRatio = meshObjects ? uvMappedMeshes / meshObjects : 0;
+  const minimumUvRatio = task.rubric.minimumUvMeshRatio;
+  add(
+    "uv_coverage",
+    uvRatio >= minimumUvRatio,
+    4,
+    `${uvMappedMeshes}/${meshObjects} meshes have UV layers; minimum ratio ${minimumUvRatio.toFixed(2)}`,
+    minimumUvRatio > 0 ? Math.min(4, (uvRatio / minimumUvRatio) * 4) : 4,
+  );
+
+  const smoothPolygons = blendMetrics?.totals?.smooth_polygons ?? 0;
+  const flatPolygons = blendMetrics?.totals?.flat_polygons ?? 0;
+  const shadedPolygons = smoothPolygons + flatPolygons;
+  const smoothRatio = shadedPolygons ? smoothPolygons / shadedPolygons : 0;
+  const minimumSmoothRatio = task.rubric.minimumSmoothFaceRatio;
+  const maximumSmoothRatio = task.rubric.maximumSmoothFaceRatio;
+  const smoothPass =
+    smoothRatio >= minimumSmoothRatio &&
+    (maximumSmoothRatio === undefined || smoothRatio <= maximumSmoothRatio);
+  let smoothPartial = 4;
+  if (smoothRatio < minimumSmoothRatio) {
+    smoothPartial =
+      minimumSmoothRatio > 0
+        ? Math.min(4, (smoothRatio / minimumSmoothRatio) * 4)
+        : 4;
+  } else if (
+    maximumSmoothRatio !== undefined &&
+    smoothRatio > maximumSmoothRatio
+  ) {
+    smoothPartial =
+      smoothRatio > 0
+        ? Math.min(4, (maximumSmoothRatio / smoothRatio) * 4)
+        : 0;
+  }
+  add(
+    "finish_shading_profile",
+    smoothPass,
+    4,
+    `${(smoothRatio * 100).toFixed(1)}% smooth polygons for ${task.rubric.finishProfile}`,
+    smoothPartial,
+  );
+
+  const refinementModifiers =
+    blendMetrics?.totals?.refinement_modifiers ?? 0;
+  const densityEvidence = triangles >= minimumTriangles * 2;
+  const refinementPass =
+    !task.rubric.requireRefinementEvidence ||
+    refinementModifiers > 0 ||
+    densityEvidence;
+  add(
+    "refinement_evidence",
+    refinementPass,
+    3,
+    task.rubric.requireRefinementEvidence
+      ? `${refinementModifiers} refinement modifiers; density evidence ${densityEvidence ? "present" : "absent"}`
+      : "Refinement modifier evidence is not required for this finish profile",
   );
 
   if (task.rubric.requireAnimation) {
@@ -215,7 +285,7 @@ export function scoreSubmission(options: {
   add(
     "deterministic_source",
     options.reproductionPass,
-    10,
+    11,
     options.reproductionPass
       ? "Source reproduced inspectable .blend and .glb outputs in a clean directory"
       : "Clean-directory source reproduction did not produce both inspectable outputs",
@@ -247,6 +317,15 @@ export function scoreSubmission(options: {
     .reduce((sum, check) => sum + check.earned, 0);
   const materialsAndPresentation = checks
     .filter((check) => ["material_count", "glb_materials"].includes(check.id))
+    .reduce((sum, check) => sum + check.earned, 0);
+  const finishQuality = checks
+    .filter((check) =>
+      [
+        "uv_coverage",
+        "finish_shading_profile",
+        "refinement_evidence",
+      ].includes(check.id),
+    )
     .reduce((sum, check) => sum + check.earned, 0);
   const animationOrAssembly = checks
     .filter((check) =>
@@ -290,6 +369,7 @@ export function scoreSubmission(options: {
         specificationCoverage +
         geometryReadiness +
         materialsAndPresentation +
+        finishQuality +
         animationOrAssembly +
         reproducibility
       ).toFixed(2),
@@ -299,6 +379,7 @@ export function scoreSubmission(options: {
       specificationCoverage,
       geometryReadiness,
       materialsAndPresentation,
+      finishQuality,
       animationOrAssembly,
       reproducibility,
     },

--- a/plugins/blender-agent-studio/skills/blender-agent-benchmark/scripts/tasks.ts
+++ b/plugins/blender-agent-studio/skills/blender-agent-benchmark/scripts/tasks.ts
@@ -1,8 +1,23 @@
 export type BenchmarkTask = {
   id: string;
   title: string;
+  category:
+    | "prop_creation"
+    | "assembly_creation"
+    | "animation_creation"
+    | "finish_quality_control";
+  capabilities: Array<
+    | "geometry"
+    | "materials"
+    | "lighting"
+    | "placement"
+    | "animation"
+    | "spatial_relations"
+    | "instruction_following"
+  >;
   suites: Array<"smoke" | "quick" | "full">;
   prompt: string;
+  visualBrief: string;
   animationFrames: number[];
   rubric: {
     requiredNameGroups: string[][];
@@ -12,6 +27,11 @@ export type BenchmarkTask = {
     maximumExtent: number;
     requireAnimation: boolean;
     minimumActionSpan?: number;
+    finishProfile: "polished_smooth" | "intentional_low_poly";
+    minimumUvMeshRatio: number;
+    minimumSmoothFaceRatio: number;
+    maximumSmoothFaceRatio?: number;
+    requireRefinementEvidence: boolean;
   };
 };
 
@@ -19,21 +39,31 @@ export const BENCHMARK_TASKS: BenchmarkTask[] = [
   {
     id: "signal_lantern",
     title: "Stylized signal lantern",
+    category: "prop_creation",
+    capabilities: [
+      "geometry",
+      "materials",
+      "lighting",
+      "spatial_relations",
+      "instruction_following",
+    ],
     suites: ["smoke", "quick", "full"],
     prompt: `Create a polished, game-ready stylized railway signal lantern in Blender.
 
-The lantern must have a stable base, a visibly separate body, a warm glass chamber with a readable light or flame inside, a protective top cap, and an arched carry handle that is visibly attached at both sides. Add enough purposeful construction detail that it reads as a manufactured prop from every side, while keeping a clean low-poly/stylized silhouette.
+The lantern must have a stable base, a visibly separate body, a warm glass chamber with a readable light or flame inside, a protective top cap, and an arched carry handle that is visibly attached at both sides. Add purposeful secondary and tertiary construction detail so it reads as a finished manufactured prop from every side. Use smooth curves, clean bevels, and polished stylized surfaces; low-poly is not requested.
 
 Requirements:
 - Use Blender Python and the Blender CLI at {{BLENDER_EXECUTABLE}}.
 - Work only in the current task directory.
 - Deliver create_asset.py, asset.blend, and asset.glb.
 - Use semantic object and material names.
-- Keep the asset under 18,000 evaluated triangles and under 3 meters on its largest axis.
+- Keep the asset under 24,000 evaluated triangles and under 3 meters on its largest axis.
 - The GLB must preserve the intended orientation and materials.
 - Include a short final_report.md describing the result and any known limitations.
 
 Do not ask follow-up questions. Build, inspect, and refine the asset before finishing.`,
+    visualBrief:
+      "A polished stylized railway signal lantern with a stable base, separate manufactured body, warm glass chamber and visible flame/light, protective cap, and a handle attached at both sides. It should have smooth curves, clean bevels, secondary and tertiary construction detail, coherent materials, and no blockout or floating-part residue.",
     animationFrames: [],
     rubric: {
       requiredNameGroups: [
@@ -46,18 +76,30 @@ Do not ask follow-up questions. Build, inspect, and refine the asset before fini
       ],
       minimumMeshObjects: 8,
       minimumMaterials: 4,
-      triangleRange: [250, 18_000],
+      triangleRange: [1_200, 24_000],
       maximumExtent: 3,
       requireAnimation: false,
+      finishProfile: "polished_smooth",
+      minimumUvMeshRatio: 0.6,
+      minimumSmoothFaceRatio: 0.35,
+      requireRefinementEvidence: true,
     },
   },
   {
     id: "tabletop_press",
     title: "Tabletop lever press",
+    category: "assembly_creation",
+    capabilities: [
+      "geometry",
+      "materials",
+      "placement",
+      "spatial_relations",
+      "instruction_following",
+    ],
     suites: ["quick", "full"],
     prompt: `Create a polished, game-ready stylized tabletop manual press in Blender.
 
-It must visibly explain how it works: a stable base supports an upright frame; a hand lever rotates around a real pivot; a connected linkage or rack drives a vertical ram; the ram aligns over a die; and a supported collection tray sits below or beside the die. Include a readable return spring or equivalent return mechanism. No major functional part should appear to float or connect only by visual coincidence.
+It must visibly explain how it works: a stable base supports an upright frame; a hand lever rotates around a real pivot; a connected linkage or rack drives a vertical ram; the ram aligns over a die; and a supported collection tray sits below or beside the die. Include a readable return spring or equivalent return mechanism. No major functional part should appear to float or connect only by visual coincidence. Finish it as a smooth, detailed manufactured prop rather than a primitive blockout. Low-poly is not requested.
 
 Requirements:
 - Use Blender Python and the Blender CLI at {{BLENDER_EXECUTABLE}}.
@@ -70,6 +112,8 @@ Requirements:
 - Include a short final_report.md describing the result and any known limitations.
 
 Do not ask follow-up questions. Build, inspect, and refine the asset before finishing.`,
+    visualBrief:
+      "A finished tabletop manual press whose base, frame, lever pivot, linkage or rack, ram, die, spring, and collection tray visibly form a plausible mechanism. The asset should have polished industrial surfaces, smooth curves and bevels where appropriate, coherent material separation, supported contacts, and no blockout residue.",
     animationFrames: [],
     rubric: {
       requiredNameGroups: [
@@ -85,14 +129,27 @@ Do not ask follow-up questions. Build, inspect, and refine the asset before fini
       ],
       minimumMeshObjects: 12,
       minimumMaterials: 3,
-      triangleRange: [400, 24_000],
+      triangleRange: [1_800, 24_000],
       maximumExtent: 3,
       requireAnimation: false,
+      finishProfile: "polished_smooth",
+      minimumUvMeshRatio: 0.6,
+      minimumSmoothFaceRatio: 0.3,
+      requireRefinementEvidence: true,
     },
   },
   {
     id: "winch_drawbridge",
     title: "Animated miniature winch drawbridge",
+    category: "animation_creation",
+    capabilities: [
+      "geometry",
+      "materials",
+      "placement",
+      "animation",
+      "spatial_relations",
+      "instruction_following",
+    ],
     suites: ["quick", "full"],
     prompt: `Create a polished, game-ready stylized miniature winch drawbridge assembly in Blender.
 
@@ -109,6 +166,8 @@ Requirements:
 - Include a short final_report.md describing the result and any known limitations.
 
 Do not ask follow-up questions. Build, inspect, and refine the asset before finishing.`,
+    visualBrief:
+      "A polished miniature winch drawbridge with sturdy supports, hinged deck, crossbeam, visible drum and crank, and two cables that remain plausibly connected throughout a lowered-to-raised cycle. Construction, pivots, materials, and finish must remain coherent in every view and critical frame.",
     animationFrames: [1, 24, 48],
     rubric: {
       requiredNameGroups: [
@@ -122,15 +181,28 @@ Do not ask follow-up questions. Build, inspect, and refine the asset before fini
       ],
       minimumMeshObjects: 12,
       minimumMaterials: 3,
-      triangleRange: [500, 28_000],
+      triangleRange: [2_200, 28_000],
       maximumExtent: 4,
       requireAnimation: true,
       minimumActionSpan: 47,
+      finishProfile: "polished_smooth",
+      minimumUvMeshRatio: 0.55,
+      minimumSmoothFaceRatio: 0.2,
+      requireRefinementEvidence: true,
     },
   },
   {
     id: "foot_pump_holdout",
     title: "Animated foot-operated air pump",
+    category: "animation_creation",
+    capabilities: [
+      "geometry",
+      "materials",
+      "placement",
+      "animation",
+      "spatial_relations",
+      "instruction_following",
+    ],
     suites: ["full"],
     prompt: `Create a polished, game-ready stylized foot-operated air pump in Blender.
 
@@ -146,6 +218,8 @@ Requirements:
 - Include a short final_report.md describing the result and any known limitations.
 
 Do not ask follow-up questions. Build, inspect, and refine the asset before finishing.`,
+    visualBrief:
+      "A polished foot-operated air pump with a stable base, hinged non-slip pedal, cylinder and driven piston connection, return spring, hose, nozzle, and readable gauge. The pumping stroke must be mechanically connected and the finished prop must not read as a primitive blockout.",
     animationFrames: [1, 18, 36],
     rubric: {
       requiredNameGroups: [
@@ -161,10 +235,120 @@ Do not ask follow-up questions. Build, inspect, and refine the asset before fini
       ],
       minimumMeshObjects: 12,
       minimumMaterials: 3,
-      triangleRange: [400, 24_000],
+      triangleRange: [1_800, 24_000],
       maximumExtent: 3,
       requireAnimation: true,
       minimumActionSpan: 35,
+      finishProfile: "polished_smooth",
+      minimumUvMeshRatio: 0.6,
+      minimumSmoothFaceRatio: 0.35,
+      requireRefinementEvidence: true,
+    },
+  },
+  {
+    id: "ceramic_lamp_finish_holdout",
+    title: "Smooth ceramic table lamp finish study",
+    category: "finish_quality_control",
+    capabilities: [
+      "geometry",
+      "materials",
+      "lighting",
+      "placement",
+      "spatial_relations",
+      "instruction_following",
+    ],
+    suites: ["full"],
+    prompt: `Create a polished, game-ready ceramic table lamp in Blender.
+
+The lamp must have a stable weighted base, a smooth ceramic body with an intentional profile, a metal neck and socket assembly, a translucent fabric shade with visible thickness and clean top and bottom rims, a bulb visible from a reasonable low angle, a small switch, and a power cord that rests naturally on the ground. The result should look like a finished portfolio prop: smooth silhouettes, controlled bevels, coherent UVs or procedural coordinates, material variation that clearly separates glazed ceramic, brushed metal, fabric, glass, and rubber, and restrained tertiary detail. This is not a low-poly request.
+
+Requirements:
+- Use Blender Python and the Blender CLI at {{BLENDER_EXECUTABLE}}.
+- Work only in the current task directory.
+- Deliver create_asset.py, asset.blend, and asset.glb.
+- Use semantic object and material names.
+- Keep the asset under 36,000 evaluated triangles and under 2 meters on its largest axis.
+- Preserve editable refinement where practical and verify the evaluated result.
+- The GLB must preserve orientation, materials, UVs, hierarchy, and smooth shading.
+- Include a short final_report.md that names the stages completed and any known limitations.
+
+Do not ask follow-up questions. Build, inspect, and refine the asset before finishing.`,
+    visualBrief:
+      "A portfolio-quality ceramic table lamp with a smooth profiled body, metal socket and neck, thick-rimmed fabric shade, bulb, switch, and naturally resting power cord. Glazed ceramic, brushed metal, fabric, glass, and rubber must read as distinct materials. Smooth finish, restrained tertiary detail, grounded contacts, and absence of blockout residue are central.",
+    animationFrames: [],
+    rubric: {
+      requiredNameGroups: [
+        ["base", "foot"],
+        ["ceramic", "body", "vessel"],
+        ["neck", "stem"],
+        ["socket", "holder"],
+        ["shade", "fabric"],
+        ["bulb", "lamp"],
+        ["switch", "toggle"],
+        ["cord", "cable", "wire"],
+      ],
+      minimumMeshObjects: 10,
+      minimumMaterials: 5,
+      triangleRange: [4_000, 36_000],
+      maximumExtent: 2,
+      requireAnimation: false,
+      finishProfile: "polished_smooth",
+      minimumUvMeshRatio: 0.75,
+      minimumSmoothFaceRatio: 0.65,
+      requireRefinementEvidence: true,
+    },
+  },
+  {
+    id: "low_poly_radio_control",
+    title: "Explicit low-poly field radio control",
+    category: "finish_quality_control",
+    capabilities: [
+      "geometry",
+      "materials",
+      "placement",
+      "spatial_relations",
+      "instruction_following",
+    ],
+    suites: ["full"],
+    prompt: `Create an intentionally low-poly, game-ready portable field radio in Blender.
+
+The style must use deliberate planar forms, selective hard edges, a compact faceted silhouette, and a small coherent color palette. Include a stable body, front speaker grille, readable tuning display, two knobs, a top carry handle attached at both sides, a short antenna with a protected base, corner guards, and a battery compartment seam. Preserve the intentionally faceted style; do not subdivide it into a smooth high-poly prop.
+
+Requirements:
+- Use Blender Python and the Blender CLI at {{BLENDER_EXECUTABLE}}.
+- Work only in the current task directory.
+- Deliver create_asset.py, asset.blend, and asset.glb.
+- Use semantic object and material names.
+- Keep the asset between 300 and 6,000 evaluated triangles and under 1 meter on its largest axis.
+- Use UVs or procedural coordinates intentionally and avoid default materials.
+- The GLB must preserve orientation, materials, hierarchy, and intentional hard edges.
+- Include a short final_report.md that names the stages completed and any known limitations.
+
+Do not ask follow-up questions. Build, inspect, and refine the asset before finishing.`,
+    visualBrief:
+      "An explicitly low-poly portable field radio with deliberate planar forms, selective hard edges, body, speaker grille, tuning display, two knobs, attached handle, protected antenna base, corner guards, and battery seam. The control tests whether intentional faceting is preserved instead of being smoothed away.",
+    animationFrames: [],
+    rubric: {
+      requiredNameGroups: [
+        ["body", "housing"],
+        ["speaker", "grille"],
+        ["display", "tuning", "dial"],
+        ["knob", "control"],
+        ["handle", "grip"],
+        ["antenna", "aerial"],
+        ["guard", "corner"],
+        ["battery", "compartment"],
+      ],
+      minimumMeshObjects: 9,
+      minimumMaterials: 3,
+      triangleRange: [300, 6_000],
+      maximumExtent: 1,
+      requireAnimation: false,
+      finishProfile: "intentional_low_poly",
+      minimumUvMeshRatio: 0.5,
+      minimumSmoothFaceRatio: 0,
+      maximumSmoothFaceRatio: 0.65,
+      requireRefinementEvidence: false,
     },
   },
 ];

--- a/plugins/blender-agent-studio/skills/blender-agent-benchmark/scripts/trace.test.ts
+++ b/plugins/blender-agent-studio/skills/blender-agent-benchmark/scripts/trace.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { summarizeAgentEvents } from "./trace.ts";
+
+describe("summarizeAgentEvents", () => {
+  test("summarizes current Codex JSON event usage and completed tools", () => {
+    const summary = summarizeAgentEvents(
+      [
+        '{"type":"thread.started","thread_id":"thread"}',
+        '{"type":"item.completed","item":{"type":"command_execution","exit_code":0}}',
+        '{"type":"item.completed","item":{"type":"mcp_tool_call","status":"failed"}}',
+        '{"type":"item.completed","item":{"type":"error","message":"warning"}}',
+        '{"type":"turn.completed","usage":{"input_tokens":100,"cached_input_tokens":20,"cache_write_input_tokens":5,"output_tokens":30,"reasoning_output_tokens":7}}',
+        "not-json",
+      ].join("\n"),
+    );
+
+    expect(summary.events).toBe(5);
+    expect(summary.invalidLines).toBe(1);
+    expect(summary.completedTurns).toBe(1);
+    expect(summary.toolCalls).toBe(2);
+    expect(summary.toolFailures).toBe(1);
+    expect(summary.errors).toBe(1);
+    expect(summary.usage).toEqual({
+      inputTokens: 100,
+      cachedInputTokens: 20,
+      cacheWriteInputTokens: 5,
+      outputTokens: 30,
+      reasoningOutputTokens: 7,
+      totalTokens: 130,
+    });
+  });
+});

--- a/plugins/blender-agent-studio/skills/blender-agent-benchmark/scripts/trace.ts
+++ b/plugins/blender-agent-studio/skills/blender-agent-benchmark/scripts/trace.ts
@@ -1,0 +1,104 @@
+export type AgentTraceSummary = {
+  events: number;
+  invalidLines: number;
+  completedTurns: number;
+  completedItemsByType: Record<string, number>;
+  toolCalls: number;
+  toolFailures: number;
+  errors: number;
+  usage: {
+    inputTokens: number;
+    cachedInputTokens: number;
+    cacheWriteInputTokens: number;
+    outputTokens: number;
+    reasoningOutputTokens: number;
+    totalTokens: number;
+  };
+};
+
+const TOOL_ITEM_TYPES = new Set([
+  "command_execution",
+  "file_change",
+  "mcp_tool_call",
+  "tool_call",
+  "web_search",
+]);
+
+function numeric(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+export function summarizeAgentEvents(stdout: string): AgentTraceSummary {
+  const summary: AgentTraceSummary = {
+    events: 0,
+    invalidLines: 0,
+    completedTurns: 0,
+    completedItemsByType: {},
+    toolCalls: 0,
+    toolFailures: 0,
+    errors: 0,
+    usage: {
+      inputTokens: 0,
+      cachedInputTokens: 0,
+      cacheWriteInputTokens: 0,
+      outputTokens: 0,
+      reasoningOutputTokens: 0,
+      totalTokens: 0,
+    },
+  };
+
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) {
+      continue;
+    }
+    let event: Record<string, unknown>;
+    try {
+      event = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      summary.invalidLines += 1;
+      continue;
+    }
+    summary.events += 1;
+    if (event.type === "turn.completed") {
+      summary.completedTurns += 1;
+      const usage = (event.usage ?? {}) as Record<string, unknown>;
+      summary.usage.inputTokens += numeric(usage.input_tokens);
+      summary.usage.cachedInputTokens += numeric(usage.cached_input_tokens);
+      summary.usage.cacheWriteInputTokens += numeric(
+        usage.cache_write_input_tokens,
+      );
+      summary.usage.outputTokens += numeric(usage.output_tokens);
+      summary.usage.reasoningOutputTokens += numeric(
+        usage.reasoning_output_tokens,
+      );
+      continue;
+    }
+    if (event.type !== "item.completed") {
+      continue;
+    }
+    const item = (event.item ?? {}) as Record<string, unknown>;
+    const itemType =
+      typeof item.type === "string" && item.type ? item.type : "unknown";
+    summary.completedItemsByType[itemType] =
+      (summary.completedItemsByType[itemType] ?? 0) + 1;
+    if (TOOL_ITEM_TYPES.has(itemType) || itemType.endsWith("_tool_call")) {
+      summary.toolCalls += 1;
+      const exitCode = item.exit_code;
+      if (
+        item.status === "failed" ||
+        item.status === "error" ||
+        (typeof exitCode === "number" && exitCode !== 0)
+      ) {
+        summary.toolFailures += 1;
+      }
+    }
+    if (itemType === "error") {
+      summary.errors += 1;
+    }
+  }
+
+  summary.usage.totalTokens =
+    summary.usage.inputTokens + summary.usage.outputTokens;
+  return summary;
+}

--- a/plugins/blender-agent-studio/skills/blender-art-direction-intake/SKILL.md
+++ b/plugins/blender-agent-studio/skills/blender-art-direction-intake/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: blender-art-direction-intake
+description: Clarify a Blender creation request and optionally generate a concept/mockup image before modeling. Use before modeling, procedural scene creation, rendering, simulation, or character work when art style, subject, scale, platform, shot, materials, constraints, or reference direction are unclear.
+---
+
+# Blender Art Direction Intake
+
+Resolve the visual contract before generating geometry. Do not ask questions
+whose answers are already explicit in the request or supplied references.
+
+## Clarify the brief
+
+Ask the smallest useful set of concise questions for unresolved decisions:
+
+- subject, purpose, platform, scale, and export target;
+- art style, reference period/genre, level of realism, and visual priorities;
+- required parts, materials, colors, logos/text, motion, and interaction;
+- camera/view requirements, lighting/mood, and whether the result is for a
+  single shot, turntable, animation, or runtime asset;
+- performance, topology, rigging, simulation, and delivery constraints.
+
+If a choice is still open, offer a concrete default and label it as an
+assumption. Stop for user input when a missing choice would materially change
+the asset's visual or technical direction.
+
+## Offer optional concept generation
+
+After clarification, offer an optional image-generation pass when a visual
+reference would reduce ambiguity. Phrase it as a choice, not a requirement:
+
+> I can generate a concept/mockup reference before modeling; it will guide
+> silhouette, materials, palette, and camera—not become the final 3D asset.
+
+When accepted, generate one focused concept using the agreed subject, style,
+material palette, environment, camera, and exclusions. Inspect it with the
+user, then record what is binding (silhouette, palette, major forms, mood) and
+what remains flexible. Do not imply image generation guarantees manufacturable
+geometry, clean topology, rigging, or a usable texture set.
+
+## Hand off
+
+Write a short approved contract with the resolved decisions, assumptions,
+reference-image path if any, and review questions. Then invoke the smallest
+appropriate workflow: modeling, procedural, rendering, simulation, character,
+or animation.

--- a/plugins/blender-agent-studio/skills/blender-art-direction-intake/agents/openai.yaml
+++ b/plugins/blender-agent-studio/skills/blender-art-direction-intake/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Blender Art Direction Intake"
+  short_description: "Clarify a Blender brief and optionally create a concept"
+  default_prompt: "Use $blender-agent-studio:blender-art-direction-intake to clarify this Blender brief and offer a concept mockup."

--- a/plugins/blender-agent-studio/skills/blender-asset-validation/SKILL.md
+++ b/plugins/blender-agent-studio/skills/blender-asset-validation/SKILL.md
@@ -22,6 +22,9 @@ $env:BLENDER_EXECUTABLE = "C:\path\to\Blender\blender.exe"
 Inspect:
 
 - evaluated vertices, edges, polygons, and triangles;
+- authored versus evaluated geometry density and refinement modifiers;
+- smooth versus flat-shaded polygon ratios;
+- UV-bearing meshes, node-based materials, image textures, and authored lights;
 - mesh objects, materials, actions, frame ranges, and hierarchy;
 - dimensions and world bounds;
 - invalid coordinates, degenerate faces, loose elements, boundary and non-manifold edges;
@@ -47,6 +50,8 @@ Open the hero and contact sheet with an image-viewing tool. Review:
 - floating or unsupported elements;
 - intersections and accidental gaps;
 - material readability;
+- visible faceting, razor edges, blockout residue, and missing or broken
+  textures;
 - whether details remain legible at intended scale.
 
 ## Verify the exported artifact

--- a/plugins/blender-agent-studio/skills/blender-asset-validation/references/quality-gates.md
+++ b/plugins/blender-agent-studio/skills/blender-asset-validation/references/quality-gates.md
@@ -34,13 +34,27 @@ Multi-part machines, foliage cards, open cloth, hair, effects meshes, and articu
 - pivots unrelated to the visible joint;
 - hidden internal detail dominating the triangle budget;
 - authored and re-imported dimensions or action counts disagree.
+- a polished or game-ready request with almost entirely flat-shaded curved
+  surfaces, no UV-bearing visible meshes, and no visible refinement evidence;
+- a result dramatically below its permitted geometry budget while still
+  reading as a graybox or generic primitive assembly;
+- missing-magenta, crushed-black, or default-gray visible surfaces;
+- coplanar or nearly coplanar surfaces likely to z-fight in a game engine;
+- final decoration that floats, penetrates walls, or has no structural or
+  compositional role.
 
 ## Visual review questions
 
 - Can the object be identified from silhouette alone?
 - Are primary, secondary, and tertiary forms proportionate?
+- Does the result read as the requested final stage, or is blockout geometry
+  still being presented as complete?
+- Are broad curves smooth enough for the intended view distance unless
+  faceting was explicitly requested?
 - Do functional parts visibly connect?
 - Are support and contact relationships believable?
 - Does the material palette describe different substances?
+- Are UVs, textures, procedural coordinates, shading, and exposure working in
+  the render engine used for evidence?
 - Does the asset remain readable in front, side, top, and perspective views?
 - Does it look correct at the intended in-game or icon scale?

--- a/plugins/blender-agent-studio/skills/blender-asset-validation/scripts/inspect_asset.py
+++ b/plugins/blender-agent-studio/skills/blender-asset-validation/scripts/inspect_asset.py
@@ -108,6 +108,7 @@ def inspect_mesh(
     obj: bpy.types.Object,
     depsgraph: bpy.types.Depsgraph,
 ) -> dict[str, Any]:
+    source_mesh = obj.data
     evaluated = obj.evaluated_get(depsgraph)
     mesh = evaluated.to_mesh(preserve_all_data_layers=True, depsgraph=depsgraph)
     try:
@@ -144,10 +145,28 @@ def inspect_mesh(
             if polygon.material_index >= len(material_slots)
             or material_slots[polygon.material_index] is None
         )
+        smooth_polygons = sum(1 for polygon in mesh.polygons if polygon.use_smooth)
+        refinement_modifiers = [
+            modifier
+            for modifier in obj.modifiers
+            if modifier.type
+            in {
+                "BEVEL",
+                "NODES",
+                "REMESH",
+                "SCREW",
+                "SKIN",
+                "SOLIDIFY",
+                "SUBSURF",
+                "WEIGHTED_NORMAL",
+            }
+        ]
 
         return {
             "name": obj.name,
             "data_name": obj.data.name if obj.data else None,
+            "source_vertices": len(source_mesh.vertices) if source_mesh else 0,
+            "source_polygons": len(source_mesh.polygons) if source_mesh else 0,
             "vertices": len(mesh.vertices),
             "edges": len(mesh.edges),
             "polygons": len(mesh.polygons),
@@ -161,11 +180,22 @@ def inspect_mesh(
             "wire_edges": wire_edges,
             "isolated_vertices": isolated_vertices,
             "uv_layers": len(mesh.uv_layers),
+            "smooth_polygons": smooth_polygons,
+            "flat_polygons": len(mesh.polygons) - smooth_polygons,
+            "smooth_polygon_ratio": (
+                round(smooth_polygons / len(mesh.polygons), 6)
+                if mesh.polygons
+                else 0.0
+            ),
             "material_slots": material_slots,
             "missing_material_faces": missing_material_faces,
             "modifiers": [
                 {"name": modifier.name, "type": modifier.type}
                 for modifier in obj.modifiers
+            ],
+            "refinement_modifiers": [
+                {"name": modifier.name, "type": modifier.type}
+                for modifier in refinement_modifiers
             ],
             "shape_keys": (
                 len(obj.data.shape_keys.key_blocks)
@@ -187,6 +217,30 @@ def inspect_action(action: bpy.types.Action) -> dict[str, Any]:
         "frame_start": round(float(start), 4),
         "frame_end": round(float(end), 4),
         "users": int(action.users),
+    }
+
+
+def inspect_material(material: bpy.types.Material) -> dict[str, Any]:
+    node_tree = material.node_tree
+    nodes = list(node_tree.nodes) if node_tree else []
+    image_texture_nodes = [
+        node
+        for node in nodes
+        if node.type == "TEX_IMAGE"
+    ]
+    images = sorted(
+        {
+            node.image.name
+            for node in image_texture_nodes
+            if getattr(node, "image", None)
+        }
+    )
+    return {
+        "name": material.name,
+        "use_nodes": bool(node_tree),
+        "node_count": len(nodes),
+        "image_texture_nodes": len(image_texture_nodes),
+        "images": images,
     }
 
 
@@ -261,7 +315,24 @@ def main() -> None:
         "polygons": sum(mesh["polygons"] for mesh in meshes),
         "triangles": sum(mesh["triangles"] for mesh in meshes),
         "materials": len(bpy.data.materials),
+        "node_materials": sum(
+            1 for material in bpy.data.materials if material.node_tree
+        ),
+        "textured_materials": sum(
+            1
+            for material in bpy.data.materials
+            if material.node_tree
+            and any(node.type == "TEX_IMAGE" for node in material.node_tree.nodes)
+        ),
+        "images": len(bpy.data.images),
+        "lights": sum(1 for obj in objects if obj["type"] == "LIGHT"),
         "actions": len(bpy.data.actions),
+        "smooth_polygons": sum(mesh["smooth_polygons"] for mesh in meshes),
+        "flat_polygons": sum(mesh["flat_polygons"] for mesh in meshes),
+        "uv_mapped_meshes": sum(1 for mesh in meshes if mesh["uv_layers"] > 0),
+        "refinement_modifiers": sum(
+            len(mesh["refinement_modifiers"]) for mesh in meshes
+        ),
         "invalid_vertices": sum(mesh["invalid_vertices"] for mesh in meshes),
         "degenerate_faces": sum(mesh["degenerate_faces"] for mesh in meshes),
         "zero_length_edges": sum(mesh["zero_length_edges"] for mesh in meshes),
@@ -297,7 +368,7 @@ def main() -> None:
         issues.append({"severity": "gate", "code": "invalid_object_transform"})
 
     output = {
-        "schema_version": 1,
+        "schema_version": 2,
         "input": str(input_path),
         "blender": {
             "version": bpy.app.version_string,
@@ -317,6 +388,10 @@ def main() -> None:
         "objects": objects,
         "meshes": meshes,
         "materials": sorted(material.name for material in bpy.data.materials),
+        "material_details": [
+            inspect_material(material)
+            for material in sorted(bpy.data.materials, key=lambda item: item.name)
+        ],
         "actions": [
             inspect_action(action)
             for action in sorted(bpy.data.actions, key=lambda item: item.name)

--- a/plugins/blender-agent-studio/skills/blender-character-workflow/SKILL.md
+++ b/plugins/blender-agent-studio/skills/blender-character-workflow/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: blender-character-workflow
+description: Create, repair, rig, skin, animate, and export Blender characters, creatures, avatars, and facial rigs with deformation and runtime validation. Use when a request involves a character mesh, armature, weights, IK/FK, blend shapes, facial animation, humanoid/VRM/game export, or deformation quality.
+---
+
+# Blender Character Workflow
+
+Character completion requires deformation evidence. A mesh plus an armature is
+not a finished rig.
+
+## Establish the character contract
+
+Record intended platform and export format, body/face scope, scale and axis,
+triangle/material/texture budgets, bone naming and hierarchy requirements,
+required controls, facial shape keys, poses/actions, and engine/avatar
+constraints. Identify the minimum acceptance poses: neutral, extreme bend for
+each major joint, reach, twist, locomotion/contact, and any required facial
+expression.
+
+## Build and rig deliberately
+
+1. Keep the authored mesh, armature, controls, deformation helpers, and export
+   mesh in named collections. Apply or deliberately preserve transforms before
+   skinning; document the choice.
+2. Create anatomically or mechanically plausible joint placement and semantic
+   bone names. Separate deform bones from animator controls where the target
+   benefits from it.
+3. Keep symmetry and mirror workflows explicit. Limit vertex influences and
+   normalize weights according to the target runtime requirements.
+4. Add IK/FK, constraints, corrective shapes, or drivers only when they solve a
+   named deformation need. Test without relying on a single flattering pose.
+5. For facial work, name shape keys semantically and test combinations that
+   reveal volume loss, collisions, or eyelid/mouth failures.
+
+## Validate export and motion
+
+1. Render the neutral and every contract pose from front, profile, back, and
+   close-up deformation views. Open the evidence.
+2. Check volume preservation, joint collapse, candy-wrapper twisting, clipping,
+   foot/hand contact, constraint cycles, control readability, and unwanted
+   scale/shear.
+3. Export to the requested format, fresh-import it in a clean Blender process,
+   and compare armature hierarchy, skin weights where supported, materials,
+   actions, frame ranges, scale, and orientation.
+4. Use `$blender-agent-studio:blender-animation-workflow` for action timing and
+   `$blender-agent-studio:blender-asset-validation` for authored/exported
+   geometry and hierarchy evidence.
+
+## Completion gate
+
+Deliver the editable source, export, bone/control map, tested pose/action list,
+and fresh-import evidence. State any target-specific validation that could not
+be performed in Blender; a successful GLB import is not proof of runtime avatar
+compatibility.

--- a/plugins/blender-agent-studio/skills/blender-character-workflow/agents/openai.yaml
+++ b/plugins/blender-agent-studio/skills/blender-character-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Blender Character Workflow"
+  short_description: "Rig, animate, and validate Blender characters and avatars"
+  default_prompt: "Use $blender-agent-studio:blender-character-workflow to create or repair and validate this Blender character."

--- a/plugins/blender-agent-studio/skills/blender-mcp-integration/references/mcp-options.md
+++ b/plugins/blender-agent-studio/skills/blender-mcp-integration/references/mcp-options.md
@@ -57,3 +57,24 @@ Use only for high-level, deterministic evaluation:
 - benchmark result preparation.
 
 It intentionally does not replace general live scene control or duplicate arbitrary-code execution.
+
+## Broader agent capability comparison
+
+The relevant ecosystem splits into complementary layers rather than a single
+server to install everywhere:
+
+| Layer | Representative implementation | Useful coverage | Studio decision |
+| --- | --- | --- | --- |
+| Official live control | Blender Lab MCP | scene/file inspection, docs, screenshots, navigation, rendering, Python | Prefer for an open Blender session on supported Blender versions. |
+| Community live/external bridge | ahujasid/blender-mcp | object/material control, screenshots, arbitrary Python, remote hosts, Poly Haven, Sketchfab, external mesh generation | Opt in only for its unique external capability and explicitly accept its credentials, downloads, telemetry, and socket surface. |
+| Broad headless automation | sandraschi/blender-mcp | mesh/sculpt, Geometry Nodes, compositor, VSE, Grease Pencil, physics, export, optional live bridge | Treat as a workflow reference or task-specific integration; do not duplicate its broad mutable tool catalog in this plugin. |
+| Deterministic evaluator | Blender Agent Studio MCP | build fingerprint, clean-process metrics, fixed evidence renders, benchmark preparation | Keep bundled and narrow; use it to verify work made through any authoring layer. |
+
+Skills should cover the durable workflow gaps across modeling, procedural
+systems, rendering, simulation, characters, animation, and validation. MCP
+tools should provide transport or local observation, not replace contracts,
+cache provenance, fresh-import checks, and visual review.
+
+Sources: https://www.blender.org/lab/mcp-server/ ;
+https://github.com/ahujasid/blender-mcp ;
+https://github.com/sandraschi/blender-mcp

--- a/plugins/blender-agent-studio/skills/blender-modeling-workflow/SKILL.md
+++ b/plugins/blender-agent-studio/skills/blender-modeling-workflow/SKILL.md
@@ -10,14 +10,57 @@ Create the asset as source-controlled Python plus generated `.blend` and `.glb` 
 ## Establish the contract
 
 1. Resolve the exact Blender executable and record `blender --version`.
-2. Convert the request into a short modeling contract before editing:
+2. Use `$blender-agent-studio:blender-art-direction-intake` before editing
+   whenever the subject, art style, visual references, materials, scale,
+   platform, or camera direction remains unclear. Offer its optional concept
+   image only after the brief is clarified.
+3. Convert the request into a short modeling contract before editing:
    - required parts and visible relationships;
    - intended style and materials;
-   - dimensions and triangle budget;
+   - intended finish quality and whether low-poly is actually requested;
+   - dimensions and an appropriate triangle range or performance target;
    - moving parts, pivots, or required contexts;
+   - named stages, review evidence, and any user approval gates;
    - deliverables and evidence views.
-3. Keep subjective goals as explicit review questions. Do not silently turn them into arbitrary geometry thresholds.
-4. Read [references/modeling-contract.md](references/modeling-contract.md) for the contract shape.
+4. Keep subjective goals as explicit review questions. Do not silently turn them into arbitrary geometry thresholds.
+5. Read [references/modeling-contract.md](references/modeling-contract.md) for the contract shape.
+
+## Default to a finished-quality asset
+
+Treat “game-ready,” “stylized,” and “optimized” as quality constraints, not as
+synonyms for visibly low-poly.
+
+- Unless the user explicitly requests low-poly, blockout-only, voxel,
+  faceted, PS1-era, or an unusually strict platform budget, target a polished
+  smooth model with clean silhouettes, bevels or support geometry, appropriate
+  subdivision or curve resolution, and readable secondary and tertiary forms.
+- Use the lowest density that preserves the intended finish from every
+  evidence view. Do not optimize away the shape language, material breaks, or
+  contact detail that makes the asset feel complete.
+- Preserve an explicitly requested low-poly style. Do not smooth or subdivide
+  away intentional planar forms merely because the normal default is polished.
+- A triangle ceiling is a limit, not a target. Do not celebrate being far under
+  budget when the result still reads as a blockout.
+
+## Work in named stages
+
+Read [references/staged-quality-workflow.md](references/staged-quality-workflow.md)
+and make the current stage explicit in progress updates and `final_report.md`.
+For a normal finished asset, use all stages:
+
+1. contract and references;
+2. graybox and proportion;
+3. primary and secondary forms;
+4. structural refinement and production topology;
+5. UVs, materials, and textures;
+6. tertiary detail, smoothing, subdivision, and presentation polish;
+7. export, fresh-import validation, and final evidence.
+
+Do not add final materials to disguise unresolved proportions or unsupported
+parts. Do not call a graybox or refined blockout “finished.” If the user asks
+for approval-gated iteration, stop after the requested stage, show multiple
+angles, and wait for approval. In noninteractive or benchmark work, perform a
+self-review at each stage and continue without asking.
 
 ## Author for iteration
 
@@ -27,7 +70,10 @@ Create the asset as source-controlled Python plus generated `.blend` and `.glb` 
 4. Give every visibly moving or functional part a plausible connection, support, guide, hinge, sleeve, rail, or parent.
 5. Keep important dimensions and animation frames as named constants near the top of the script.
 6. Preserve editable construction where useful, but evaluate modifiers before measuring exported geometry.
-7. Read [references/procedural-patterns.md](references/procedural-patterns.md) when implementing reusable Blender helpers.
+7. Use bevel, subdivision, weighted normals, smooth shading, curve resolution,
+   or deliberate manual topology according to the requested style. Inspect the
+   evaluated result rather than assuming a modifier equals polish.
+8. Read [references/procedural-patterns.md](references/procedural-patterns.md) when implementing reusable Blender helpers.
 
 ## Execute and inspect
 
@@ -59,6 +105,14 @@ Do not call the model complete until:
 - the source script reruns from a clean Blender process;
 - generated artifacts open after fresh GLB import;
 - technical gates appropriate to the task pass;
+- every required stage reached its exit criteria or was explicitly excluded by
+  the user;
+- the asset no longer reads as a blockout from any required view unless a
+  blockout was the requested deliverable;
+- curves and broad surfaces are smooth enough for the intended view distance,
+  while explicitly low-poly forms retain their intentional faceting;
+- materials describe the requested substances and visible UV, texture,
+  shading, or lighting failures are resolved;
 - required parts and spatial relationships are visible from the evidence views;
 - no major component reads as floating, accidental, or mechanically unexplained;
 - the final response includes the source, `.blend`, `.glb`, metrics, and rendered evidence paths.

--- a/plugins/blender-agent-studio/skills/blender-modeling-workflow/agents/openai.yaml
+++ b/plugins/blender-agent-studio/skills/blender-modeling-workflow/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Blender Modeling Workflow"
-  short_description: "Build reproducible Blender models via code"
-  default_prompt: "Use $blender-agent-studio:blender-modeling-workflow to create or refine a reproducible Blender model from this request."
+  short_description: "Build polished Blender models in explicit stages"
+  default_prompt: "Use $blender-agent-studio:blender-modeling-workflow to create or refine a reproducible Blender model in explicit stages from graybox through polished, textured, validated final output."

--- a/plugins/blender-agent-studio/skills/blender-modeling-workflow/references/modeling-contract.md
+++ b/plugins/blender-agent-studio/skills/blender-modeling-workflow/references/modeling-contract.md
@@ -22,10 +22,30 @@ Write a compact JSON or Markdown contract before substantial modeling:
     "tablet exits into tray"
   ],
   "style": ["stylized", "worn painted metal"],
+  "finish": {
+    "profile": "polished_smooth",
+    "low_poly_explicitly_requested": false,
+    "surface_targets": [
+      "smooth outer silhouette",
+      "beveled manufactured edges",
+      "readable secondary and tertiary detail",
+      "no visible blockout residue"
+    ]
+  },
   "limits": {
-    "triangle_max": 5000,
+    "triangle_range": [4000, 24000],
     "maximum_extent_m": 1.5
   },
+  "stages": [
+    "contract_and_references",
+    "graybox",
+    "primary_secondary_forms",
+    "structural_refinement",
+    "materials_textures",
+    "surface_polish",
+    "export_validation"
+  ],
+  "approval_gates": [],
   "animation": {
     "required": true,
     "critical_frames": [1, 18, 36, 60, 84, 96]
@@ -44,3 +64,8 @@ Separate:
 - hard gates: execution, export, required parts, numeric limits;
 - measurable quality: topology, dimensions, material coverage, motion continuity;
 - perceptual review: style, visual coherence, physical plausibility, polish.
+
+Record whether the user actually requested low-poly. If not, use
+`polished_smooth` as the normal finish profile. A triangle maximum is a ceiling,
+not evidence that the model is finished; prefer a range or platform-specific
+performance target when one is known.

--- a/plugins/blender-agent-studio/skills/blender-modeling-workflow/references/procedural-patterns.md
+++ b/plugins/blender-agent-studio/skills/blender-modeling-workflow/references/procedural-patterns.md
@@ -11,7 +11,13 @@
 
 - Build primary dimensions from constants rather than scattered literals.
 - Apply bevels proportionally to object scale.
-- Use enough radial segments for silhouette quality, not hidden density.
+- Unless low-poly is explicit, use enough radial segments for a smooth intended
+  silhouette and judge them from the closest required evidence view.
+- Use subdivision only where the control topology and silhouette benefit from
+  it. Hard-surface parts may instead use bevels, weighted normals, or deliberate
+  manual topology.
+- Keep an editable refinement stack in the authored `.blend` when practical,
+  then inspect the evaluated and exported result.
 - Prefer separate objects for articulated parts and intentional material boundaries.
 - Avoid coplanar duplicate faces and decorative geometry fully buried inside other solids.
 - Generate simple collision proxies separately when a game asset needs them.
@@ -21,6 +27,11 @@
 - Use a small coherent palette.
 - Set Principled BSDF inputs explicitly.
 - Make roughness and metallic differences support material identity.
+- Use UVs, procedural coordinates, or authored textures intentionally. A set of
+  differently colored flat materials is not a complete texture pass when the
+  requested substances need surface variation.
+- Check for missing or magenta textures, crushed black materials, overexposure,
+  and insufficient contrast in the actual render engine used for evidence.
 - Avoid relying on one camera or lighting setup to hide weak geometry.
 
 ## Animation

--- a/plugins/blender-agent-studio/skills/blender-modeling-workflow/references/staged-quality-workflow.md
+++ b/plugins/blender-agent-studio/skills/blender-modeling-workflow/references/staged-quality-workflow.md
@@ -1,0 +1,83 @@
+# Staged quality workflow
+
+Use these stages for finished asset work. A stage is complete only when its exit
+criteria are visible in evidence or measurable in the scene.
+
+## 1. Contract and references
+
+- Record required parts, spatial relationships, style, scale, finish profile,
+  performance target, deliverables, and review views.
+- Record whether low-poly is explicitly requested.
+- Identify the intended view distance and the hardest silhouette or contact
+  relationship to judge.
+
+Exit when the modeling contract and review questions are explicit.
+
+## 2. Graybox and proportion
+
+- Build only major masses, room volumes, clearances, pivots, and contact planes.
+- Use neutral materials and labels where they improve spatial review.
+- Check scale, silhouette, negative space, access, and the relationship between
+  every required major part.
+
+Exit when proportions and layout work from front, side, top, and perspective
+views. A graybox is not a finished asset.
+
+## 3. Primary and secondary forms
+
+- Replace proxy primitives with intentional shapes.
+- Add real supports, attachments, openings, handles, panels, seams, and
+  transitions that explain construction.
+- Establish the visual hierarchy before small decoration.
+
+Exit when the asset is identifiable from silhouette and no functional part
+looks attached by coincidence.
+
+## 4. Structural refinement and production topology
+
+- Resolve intersections, floating parts, wall penetration, z-fighting, thin
+  unsupported spans, pivots, normals, and deformation or export risks.
+- Add bevels, support loops, subdivision, weighted normals, curve resolution,
+  or manual topology appropriate to the finish profile.
+- Preserve intentional low-poly faceting only when requested.
+
+Exit when the evaluated geometry is clean, all contact relationships are
+believable, and broad curves do not look accidentally faceted.
+
+## 5. UVs, materials, and textures
+
+- Give visible meshes intentional UVs or procedural coordinates.
+- Build materials that describe distinct substances through color, roughness,
+  metallic, transmission, normal, and restrained surface variation.
+- Verify texture paths and render-engine compatibility.
+
+Exit when no surface reads as default gray, accidental black, missing-magenta,
+or indistinguishable from a different requested substance.
+
+## 6. Tertiary detail and presentation polish
+
+- Add only detail that reinforces scale, use, construction, wear, or style.
+- Inspect the closest required view for faceting, razor edges, blockout residue,
+  arbitrary decoration, noisy detail, and weak focal hierarchy.
+- Balance lighting and exposure; do not use lighting to hide geometry defects.
+
+Exit when the asset reads as intentionally finished from every required view,
+not merely acceptable from the hero camera.
+
+## 7. Export and fresh-import validation
+
+- Save the authored `.blend`, export the requested runtime format, and import it
+  in a fresh Blender process.
+- Compare names, hierarchy, dimensions, materials, UVs, shading, animation, and
+  critical frames.
+- Render the final multiview evidence from the exported artifact when practical.
+
+Exit when the durable source reproduces the deliverables and both authored and
+fresh-imported assets pass the applicable gates.
+
+## Approval behavior
+
+When the user requests approval-gated work, stop at the agreed stage boundary,
+show multiple useful angles, state what is intentionally unfinished, and wait.
+Do not advance because the current stage is technically valid. When no approval
+gate was requested, keep the same stages but self-review and continue.

--- a/plugins/blender-agent-studio/skills/blender-procedural-workflow/SKILL.md
+++ b/plugins/blender-agent-studio/skills/blender-procedural-workflow/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: blender-procedural-workflow
+description: Create reproducible Blender Geometry Nodes, modifiers, instancing systems, and procedural environments. Use when a request involves Geometry Nodes, scattering, terrain, architecture, repeated assets, parametric generators, non-destructive variation, or scalable scene assembly.
+---
+
+# Blender Procedural Workflow
+
+Build an editable generator with an explicit parameter contract, not a one-off
+node graph that only works for its current input.
+
+## Define the generator contract
+
+Identify inputs, units, random seed, variation controls, source assets,
+performance budget, expected output geometry, and what the user may safely
+change. State invariants such as non-overlap, terrain conformity, cardinal
+orientation, density limits, stable IDs, or export realization.
+
+Name node groups, sockets, modifiers, collections, materials, and instances
+semantically. Keep input assets separate from generated output and do not hide
+critical behavior in unnamed internal values.
+
+## Author in layers
+
+1. Start with a minimal graph proving the major transformation or placement
+   rule. Test its output from multiple views before adding variation.
+2. Expose only meaningful controls at the group interface, with units, ranges,
+   defaults, and clear names. Keep dependent constants in the durable Python
+   source where agents can regenerate them.
+3. Use deterministic seed handling. When instances must remain stable across
+   revisions, derive randomness from stable element IDs rather than evaluation
+   order.
+4. Prefer instancing for repeated assets; realize instances only for operations
+   or exports that require real geometry. Measure evaluated triangle counts and
+   memory implications after realization.
+5. For terrain/scatter systems, validate slope, normal alignment, collision or
+   exclusion zones, density falloff, scale range, clipping, and silhouette.
+6. For modifiers and node graphs that feed animation or simulation, define the
+   evaluation order and cache/bake boundary explicitly.
+
+## Test the parameter surface
+
+Render and inspect the default, minimum, maximum, and at least one seeded
+variation. Test empty/small and dense/large inputs where meaningful. A graph
+that looks good at a single seed or density is not reusable.
+
+Use `$blender-agent-studio:blender-asset-validation` to inspect evaluated
+output, transforms, materials, and exported geometry. For final art-directed
+images, use `$blender-agent-studio:blender-rendering-workflow`.
+
+## Completion gate
+
+Deliver the source script, `.blend`, parameter list, seed, input-asset
+requirements, and evidence for the tested configurations. State whether the
+export retains the procedural graph or is intentionally realized/baked, since
+GLB and other runtime formats do not preserve Geometry Nodes behavior.

--- a/plugins/blender-agent-studio/skills/blender-procedural-workflow/agents/openai.yaml
+++ b/plugins/blender-agent-studio/skills/blender-procedural-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Blender Procedural Workflow"
+  short_description: "Create editable Geometry Nodes and procedural scene systems"
+  default_prompt: "Use $blender-agent-studio:blender-procedural-workflow to build and validate this Blender generator."

--- a/plugins/blender-agent-studio/skills/blender-rendering-workflow/SKILL.md
+++ b/plugins/blender-agent-studio/skills/blender-rendering-workflow/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: blender-rendering-workflow
+description: Build, diagnose, and deliver Blender still, turntable, sequence, and animation renders with reproducible lighting, camera, color-management, compositor, and output settings. Use when a request concerns product visualization, cinematic shots, architectural renders, look development, render passes, denoising, compositing, or final image/video delivery.
+---
+
+# Blender Rendering Workflow
+
+Treat a render as a reproducible deliverable, not a screenshot that happened to
+look acceptable once.
+
+## Establish the render contract
+
+Before changing the scene, record:
+
+- the intended audience, view distance, reference mood, and required story beat;
+- still, turntable, image sequence, or video deliverable; resolution, frame
+  range, frame rate, and output format;
+- render engine, device assumptions, time/noise budget, and whether the result
+  must match an engine or compositor downstream;
+- required cameras, hero and diagnostic views, render passes, alpha, and color
+  management requirements;
+- which lights, world, materials, volumes, and compositor nodes are part of the
+  authored result.
+
+Keep these settings as named constants in the durable scene-generation script.
+Do not use a viewport screenshot as final evidence when the request calls for a
+rendered deliverable.
+
+## Author for repeatability
+
+1. Name cameras, lights, world nodes, view layers, render settings, and output
+   nodes semantically.
+2. Set engine, resolution, frame range, sampling, denoise policy, transparent
+   film, and color-management explicitly; never rely on a startup-file default.
+3. Frame the subject with a deliberate focal length and camera height before
+   increasing samples or adding post-processing.
+4. Light for form: establish key, fill, rim/background separation, contact
+   shadow, and exposure before cosmetic effects. Keep enough neutral evidence
+   lighting to expose intersections and texture failures.
+5. Use render passes and compositor nodes only when they improve the requested
+   result. Keep the uncomposited beauty output available for diagnosis.
+6. For turntables and animated output, render a short low-cost preview first;
+   then lock camera and lighting before the final frame range.
+7. For a render farm or external engine, emit a self-contained handoff manifest
+   listing Blender version, engine, device assumptions, assets, fonts, cache
+   paths, frame range, and output settings.
+
+## Iterate with evidence
+
+1. Render a low-sample diagnostic frame for every required camera.
+2. Open the rendered images, not merely file-existence logs.
+3. Check composition, silhouette separation, exposure, specular control,
+   shadow grounding, color balance, texture scale, noise/fireflies, clipping,
+   and whether the requested material reads correctly.
+4. Correct scene, material, camera, or lighting causes before tuning denoise,
+   bloom, depth of field, or grading to hide them.
+5. Render final stills or a bounded preview sequence. Open a contact sheet and,
+   for motion, the encoded video or sampled frames.
+
+## Completion gate
+
+Do not call a render complete until the source reproduces it in a clean Blender
+process and the final output has been visually opened. Report exact output
+paths, Blender and engine version, resolution, frame range, samples/denoise,
+color management, passes, render duration, and any machine-specific limits.
+Use `$blender-agent-studio:blender-asset-validation` for fixed multiview
+geometry evidence; that evidence supplements rather than replaces the art
+directed final render.

--- a/plugins/blender-agent-studio/skills/blender-rendering-workflow/agents/openai.yaml
+++ b/plugins/blender-agent-studio/skills/blender-rendering-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Blender Rendering Workflow"
+  short_description: "Create reproducible Blender stills and animation renders"
+  default_prompt: "Use $blender-agent-studio:blender-rendering-workflow to light, render, and validate this Blender deliverable."

--- a/plugins/blender-agent-studio/skills/blender-simulation-workflow/SKILL.md
+++ b/plugins/blender-agent-studio/skills/blender-simulation-workflow/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: blender-simulation-workflow
+description: Create, diagnose, bake, and validate deterministic Blender physics simulations including fluid, smoke, fire, rigid bodies, cloth, soft bodies, particles, and hair. Use when a request involves physical dynamics, collision, cache baking, fluid or volume output, simulation handoff, or rendering a simulation.
+---
+
+# Blender Simulation Workflow
+
+Simulation is a cache-producing build step. Preserve the setup and cache
+provenance; a visually plausible single frame is not proof that it is stable.
+
+## Define the simulation contract
+
+Record the simulation type, solver, timeline, scale, gravity/forces, collision
+objects, emitters, domain bounds, desired behavior, cache location, resolution
+or substeps, and deliverable format. State the frames that establish onset,
+peak interaction, and settle. For fluids, explicitly distinguish liquid from
+gas/fire/smoke and whether a mesh, particles, or volume is the deliverable.
+
+Use a project-local cache directory outside source control. Never overwrite an
+existing approved bake without creating a new output location or explicit user
+approval.
+
+## Build a controlled setup
+
+1. Apply or account for object scale; use real-world scene scale and record
+   units. Mis-scaled colliders and domains invalidate tuning conclusions.
+2. Name domain, flow/emitter, effector/collider, force, cache, and output
+   objects semantically. Keep a collection for inputs separate from generated
+   mesh, volume, particles, or bake artifacts.
+3. Start with a short, coarse preview cache to prove the causal setup,
+   collision direction, and timing. Do not begin a costly final bake before
+   opening preview evidence.
+4. For fluid/smoke/fire, bound the domain tightly enough to control cost while
+   leaving required motion margin. Use Modular or Final cache intentionally;
+   document the ordered bake stages when applicable.
+5. For rigid, cloth, soft-body, particle, or hair work, establish collider
+   thickness, substeps, damping/friction, self-collision, and pin/attachment
+   constraints before aesthetic forces or turbulence.
+6. Set seeds explicitly for stochastic effects. Preserve cache settings and
+   simulator version alongside the generation script.
+
+## Bake and validate
+
+1. Bake the preview, then inspect the specified critical frames from at least
+   two useful cameras.
+2. Check that emitters and colliders affect the result at the intended time;
+   that domains do not clip it; that collision does not tunnel, explode, or
+   penetrate; and that mass, drag, settling, and scale read plausibly.
+3. Change one causal parameter group at a time, invalidate the affected cache,
+   and rebake the smallest frame interval that proves the change.
+4. Bake final data only after the preview passes. Verify every expected cache
+   stage/file is present and the timeline reads it rather than recomputing an
+   implicit temporary state.
+5. Render the requested critical frames and, when timing matters, an encoded
+   preview or final sequence using `$blender-agent-studio:blender-rendering-workflow`.
+
+## Completion gate
+
+Deliver the reproducible setup script or `.blend`, cache manifest (type,
+location, frames, resolution/substeps, seed, Blender version), final cache or
+exported simulation artifact as requested, and visually inspected evidence.
+Report the scope honestly: a short cache preview validates those frames only;
+it does not validate the full final timeline. Use asset validation after
+converting a simulation to a mesh or export format.

--- a/plugins/blender-agent-studio/skills/blender-simulation-workflow/agents/openai.yaml
+++ b/plugins/blender-agent-studio/skills/blender-simulation-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Blender Simulation Workflow"
+  short_description: "Build and validate fluid, physics, cloth, and particle bakes"
+  default_prompt: "Use $blender-agent-studio:blender-simulation-workflow to create and validate this Blender simulation."


### PR DESCRIPTION
## Summary
- add art-direction intake with optional concept-image references
- add procedural, rendering, simulation, and character workflows
- expand validation and benchmark guidance while retaining the bounded MCP design

## Validation
- bun run check
- bun run test
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added art-direction intake with optional concept-image references.
- Added procedural, rendering, simulation, and character workflows.
- Expanded staged modeling, validation, export, and quality guidance.
- Expanded benchmark tasks, finish-quality scoring, visual judging, and execution metrics.
- Retained bounded MCP integration guidance.
- Validation commands: `bun run check`, `bun run test`, and `git diff --check`.

| Author | Lines added | Lines removed |
|---|---:|---:|
| Not available from the provided change summary | — | — |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->